### PR TITLE
Type safety for syscall arguments and returns.

### DIFF
--- a/src/imp/libc/fs/dir.rs
+++ b/src/imp/libc/fs/dir.rs
@@ -1,5 +1,5 @@
-use super::super::conv::owned_fd;
 use super::FileType;
+use crate::imp::libc::conv::owned_fd;
 use crate::io::{self, OwnedFd, RawFd};
 use errno::{errno, set_errno, Errno};
 use io_lifetimes::{AsFd, BorrowedFd, IntoFd};

--- a/src/imp/libc/io/epoll.rs
+++ b/src/imp/libc/io/epoll.rs
@@ -58,7 +58,7 @@
 //! # }
 //! ```
 
-use super::super::conv::{ret, ret_owned_fd, ret_u32};
+use crate::imp::libc::conv::{ret, ret_owned_fd, ret_u32};
 use crate::io;
 use crate::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use bitflags::bitflags;

--- a/src/imp/libc/io/mod.rs
+++ b/src/imp/libc/io/mod.rs
@@ -6,12 +6,9 @@ mod types;
 pub mod epoll;
 pub use error::Error;
 pub use poll_fd::{PollFd, PollFlags};
-#[cfg(any(
-    linux_raw,
-    all(
-        libc,
-        not(any(target_os = "ios", target_os = "macos", target_os = "wasi"))
-    )
+#[cfg(all(
+    libc,
+    not(any(target_os = "ios", target_os = "macos", target_os = "wasi"))
 ))]
 pub use types::PipeFlags;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]

--- a/src/imp/libc/io/poll_fd.rs
+++ b/src/imp/libc/io/poll_fd.rs
@@ -1,4 +1,4 @@
-use super::super::conv::borrowed_fd;
+use crate::imp::libc::conv::borrowed_fd;
 use bitflags::bitflags;
 use io_lifetimes::{AsFd, BorrowedFd};
 use std::marker::PhantomData;

--- a/src/imp/libc/offset.rs
+++ b/src/imp/libc/offset.rs
@@ -97,7 +97,7 @@ pub(super) use libc::{preadv as libc_preadv, pwritev as libc_pwritev};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 mod readwrite_pv {
     weakcall! {
-        pub(in super::super) fn preadv(
+        pub(in crate::imp::libc) fn preadv(
             fd: libc::c_int,
             iov: *const libc::iovec,
             iovcnt: libc::c_int,
@@ -105,7 +105,7 @@ mod readwrite_pv {
         ) -> libc::ssize_t
     }
     weakcall! {
-        pub(in super::super) fn pwritev(
+        pub(in crate::imp::libc) fn pwritev(
             fd: libc::c_int,
             iov: *const libc::iovec,
             iovcnt: libc::c_int, offset: libc::off_t

--- a/src/imp/linux_raw/arch/inline/aarch64.rs
+++ b/src/imp/linux_raw/arch/inline/aarch64.rs
@@ -1,245 +1,276 @@
+use crate::imp::linux_raw::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
+        in("x8") nr.to_asm(),
         out("x0") r0,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1(nr: SyscallNumber, a0: ArgReg<A0>) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(nr: SyscallNumber, a0: ArgReg<A0>) -> ! {
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        in("x0") a0,
+        in("x8") nr.to_asm(),
+        in("x0") a0.to_asm(),
         options(noreturn)
     )
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
-        in("x4") a4,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
+        in("x4") a4.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
-        in("x4") a4,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
+        in("x4") a4.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
-        in("x4") a4,
-        in("x5") a5,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
+        in("x4") a4.to_asm(),
+        in("x5") a5.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "svc 0",
-        in("x8") nr as usize,
-        inlateout("x0") a0 => r0,
-        in("x1") a1,
-        in("x2") a2,
-        in("x3") a3,
-        in("x4") a4,
-        in("x5") a5,
+        in("x8") nr.to_asm(),
+        inlateout("x0") a0.to_asm() => r0,
+        in("x1") a1.to_asm(),
+        in("x2") a2.to_asm(),
+        in("x3") a3.to_asm(),
+        in("x4") a4.to_asm(),
+        in("x5") a5.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }

--- a/src/imp/linux_raw/arch/inline/mod.rs
+++ b/src/imp/linux_raw/arch/inline/mod.rs
@@ -12,10 +12,10 @@ mod x86;
 mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) use self::aarch64::*;
+pub(in crate::imp::linux_raw) use self::aarch64::*;
 #[cfg(target_arch = "riscv64")]
-pub(crate) use self::riscv64::*;
+pub(in crate::imp::linux_raw) use self::riscv64::*;
 #[cfg(target_arch = "x86")]
-pub(crate) use self::x86::*;
+pub(in crate::imp::linux_raw) use self::x86::*;
 #[cfg(target_arch = "x86_64")]
-pub(crate) use self::x86_64::*;
+pub(in crate::imp::linux_raw) use self::x86_64::*;

--- a/src/imp/linux_raw/arch/inline/riscv64.rs
+++ b/src/imp/linux_raw/arch/inline/riscv64.rs
@@ -1,245 +1,276 @@
+use crate::imp::linux_raw::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
+        in("a7") nr.to_asm(),
         out("a0") r0,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1(nr: SyscallNumber, a0: ArgReg<A0>) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(nr: SyscallNumber, a0: ArgReg<A0>) -> ! {
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        in("a0") a0,
+        in("a7") nr.to_asm(),
+        in("a0") a0.to_asm(),
         options(noreturn)
     );
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
-        in("a4") a4,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
-        in("a4") a4,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
-        in("a4") a4,
-        in("a5") a5,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        in("a5") a5.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "ecall",
-        in("a7") nr as usize,
-        inlateout("a0") a0 => r0,
-        in("a1") a1,
-        in("a2") a2,
-        in("a3") a3,
-        in("a4") a4,
-        in("a5") a5,
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        in("a5") a5.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }

--- a/src/imp/linux_raw/arch/inline/x86.rs
+++ b/src/imp/linux_raw/arch/inline/x86.rs
@@ -6,98 +6,112 @@
 
 #![allow(dead_code)]
 
-use super::super::super::vdso_wrappers::SyscallType;
+use crate::imp::linux_raw::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use crate::imp::linux_raw::vdso_wrappers::SyscallType;
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall0(callee: SyscallType, nr: u32) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall0(
+    callee: SyscallType,
+    nr: SyscallNumber,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "call {callee}",
         callee = in(reg) callee,
-        inlateout("eax") nr as usize => r0,
+        inlateout("eax") nr.to_asm() => r0,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall1(callee: SyscallType, nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall1(
+    callee: SyscallType,
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "call {callee}",
         callee = in(reg) callee,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
-pub(crate) unsafe fn indirect_syscall1_noreturn(callee: SyscallType, nr: u32, a0: usize) -> ! {
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall1_noreturn(
+    callee: SyscallType,
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> ! {
     asm!(
         "call {callee}",
         callee = in(reg) callee,
-        in("eax") nr as usize,
-        in("ebx") a0,
+        in("eax") nr.to_asm(),
+        in("ebx") a0.to_asm(),
         options(noreturn)
     )
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall2(
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall2(
     callee: SyscallType,
-    nr: u32,
-    a0: usize,
-    a1: usize,
-) -> usize {
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "call {callee}",
         callee = in(reg) callee,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall3(
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall3(
     callee: SyscallType,
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-) -> usize {
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "call {callee}",
         callee = in(reg) callee,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall4(
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall4(
     callee: SyscallType,
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-) -> usize {
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     // a3 should go in esi, but asm! won't let us use it as an operand.
     // temporarily swap it into place, and then swap it back afterward.
@@ -109,28 +123,28 @@ pub(crate) unsafe fn indirect_syscall4(
         "xchg esi, {a3}",
         "call edi",
         "xchg esi, {a3}",
-        a3 = in(reg) a3,
+        a3 = in(reg) a3.to_asm(),
         in("edi") callee,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn indirect_syscall5(
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall5(
     callee: SyscallType,
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     // Oof. a3 should go in esi, and asm! won't let us use that register as
     // an operand. And we can't request stack slots. And there are no other
@@ -146,28 +160,28 @@ pub(crate) unsafe fn indirect_syscall5(
         "pop esi",
         "pop esi",
         "pop ebp",
-        inout("eax") &[callee as usize, a3, nr as usize] => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        inout("eax") &[callee as usize, a3.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[allow(clippy::too_many_arguments)]
 #[inline]
-pub(crate) unsafe fn indirect_syscall6(
+pub(in crate::imp::linux_raw) unsafe fn indirect_syscall6(
     callee: SyscallType,
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     // Oof again. a3 should go in esi, and a5 should go in ebp, and asm! won't
     // let us use either of those registers as operands. And we can't request
@@ -188,125 +202,152 @@ pub(crate) unsafe fn indirect_syscall6(
         "pop esi",
         "pop esi",
         "pop ebp",
-        inout("eax") &[callee as usize, a3, a5, nr as usize] => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        inout("eax") &[callee as usize, a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
+        inlateout("eax") nr.to_asm() => r0,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1(nr: SyscallNumber, a0: ArgReg<A0>) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
-pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(nr: SyscallNumber, a0: ArgReg<A0>) -> ! {
     asm!(
         "int $$0x80",
-        in("eax") nr as usize,
-        in("ebx") a0,
+        in("eax") nr.to_asm(),
+        in("ebx") a0.to_asm(),
         options(noreturn)
     )
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "int $$0x80",
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     // a3 should go in esi, but asm! won't let us use it as an operand.
     // Temporarily swap it into place, and then swap it back afterward.
@@ -314,50 +355,50 @@ pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usiz
         "xchg esi, {a3}",
         "int $$0x80",
         "xchg esi, {a3}",
-        a3 = in(reg) a3,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "xchg esi, {a3}",
         "int $$0x80",
         "xchg esi, {a3}",
-        a3 = in(reg) a3,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     // As in syscall 4, use xchg to handle a3. a4 should go in edi, and
     // we can use that register as an operand.
@@ -365,54 +406,54 @@ pub(crate) unsafe fn syscall5(
         "xchg esi, {a3}",
         "int $$0x80",
         "xchg esi, {a3}",
-        a3 = in(reg) a3,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "xchg esi, {a3}",
         "int $$0x80",
         "xchg esi, {a3}",
-        a3 = in(reg) a3,
-        inlateout("eax") nr as usize => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     // Oof. a3 should go in esi, and a5 should go in ebp, and asm! won't
     // let us use either of those registers as operands. And we can't request
@@ -431,27 +472,27 @@ pub(crate) unsafe fn syscall6(
         "int $$0x80",
         "pop esi",
         "pop ebp",
-        inout("eax") &[a3, a5, nr as usize] => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        inout("eax") &[a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "push ebp",
@@ -462,12 +503,12 @@ pub(crate) unsafe fn syscall6_readonly(
         "int $$0x80",
         "pop esi",
         "pop ebp",
-        inout("eax") &[a3, a5, nr as usize] => r0,
-        in("ebx") a0,
-        in("ecx") a1,
-        in("edx") a2,
-        in("edi") a4,
+        inout("eax") &[a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
         options(preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }

--- a/src/imp/linux_raw/arch/inline/x86_64.rs
+++ b/src/imp/linux_raw/arch/inline/x86_64.rs
@@ -1,272 +1,303 @@
+use crate::imp::linux_raw::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+
 #[cfg(target_pointer_width = "32")]
 compile_error!("x32 is not yet supported");
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
+        inlateout("rax") nr.to_asm() => r0,
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1(nr: SyscallNumber, a0: ArgReg<A0>) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
-pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(nr: SyscallNumber, a0: ArgReg<A0>) -> ! {
     asm!(
         "syscall",
-        in("rax") nr,
-        in("rdi") a0,
+        in("rax") nr.to_asm(),
+        in("rdi") a0.to_asm(),
         options(noreturn)
     )
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall4_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
-        in("r8") a4,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
+        in("r8") a4.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall5_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
-        in("r8") a4,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
+        in("r8") a4.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
-        in("r8") a4,
-        in("r9") a5,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
+        in("r8") a4.to_asm(),
+        in("r9") a5.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags)
     );
-    r0
+    FromAsm::from_asm(r0)
 }
 
 #[inline]
 #[must_use]
-pub(crate) unsafe fn syscall6_readonly(
-    nr: u32,
-    a0: usize,
-    a1: usize,
-    a2: usize,
-    a3: usize,
-    a4: usize,
-    a5: usize,
-) -> usize {
+pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+    nr: SyscallNumber,
+    a0: ArgReg<A0>,
+    a1: ArgReg<A1>,
+    a2: ArgReg<A2>,
+    a3: ArgReg<A3>,
+    a4: ArgReg<A4>,
+    a5: ArgReg<A5>,
+) -> RetReg<R0> {
     let r0;
     asm!(
         "syscall",
-        inlateout("rax") nr as usize => r0,
-        in("rdi") a0,
-        in("rsi") a1,
-        in("rdx") a2,
-        in("r10") a3,
-        in("r8") a4,
-        in("r9") a5,
+        inlateout("rax") nr.to_asm() => r0,
+        in("rdi") a0.to_asm(),
+        in("rsi") a1.to_asm(),
+        in("rdx") a2.to_asm(),
+        in("r10") a3.to_asm(),
+        in("r8") a4.to_asm(),
+        in("r9") a5.to_asm(),
         out("rcx") _,
         out("r11") _,
         options(nostack, preserves_flags, readonly)
     );
-    r0
+    FromAsm::from_asm(r0)
 }

--- a/src/imp/linux_raw/arch/mod.rs
+++ b/src/imp/linux_raw/arch/mod.rs
@@ -7,29 +7,29 @@
 
 // When inline asm is available, use it.
 #[cfg(linux_raw_inline_asm)]
-pub(crate) mod inline;
+pub(in crate::imp::linux_raw) mod inline;
 #[cfg(linux_raw_inline_asm)]
-pub(crate) use self::inline as asm;
+pub(in crate::imp::linux_raw) use self::inline as asm;
 
 // When inline asm isn't available, use out-of-line asm.
 #[cfg(not(linux_raw_inline_asm))]
-pub(crate) mod outline;
+pub(in crate::imp::linux_raw) mod outline;
 #[cfg(not(linux_raw_inline_asm))]
-pub(crate) use self::outline as asm;
+pub(in crate::imp::linux_raw) use self::outline as asm;
 
 // On most architectures, the architecture syscall instruction is fast, so use
 // it directly.
 #[cfg(target_arch = "aarch64")]
-pub(crate) use self::asm as choose;
+pub(in crate::imp::linux_raw) use self::asm as choose;
 #[cfg(target_arch = "x86_64")]
-pub(crate) use self::asm as choose;
+pub(in crate::imp::linux_raw) use self::asm as choose;
 #[cfg(target_arch = "riscv64")]
-pub(crate) use self::asm as choose;
+pub(in crate::imp::linux_raw) use self::asm as choose;
 
 // On x86, use vDSO wrappers for all syscalls. We could use the architecture
 // syscall instruction (int 0x80), but the vDSO kernel_vsyscall mechanism is
 // much faster.
 #[cfg(target_arch = "x86")]
-pub(crate) use super::vdso_wrappers::x86_via_vdso as choose;
+pub(in crate::imp::linux_raw) use super::vdso_wrappers::x86_via_vdso as choose;
 //#[cfg(target_arch = "x86")]
-//pub(crate) use self::asm as choose;
+//pub(in crate::imp::linux_raw) use self::asm as choose;

--- a/src/imp/linux_raw/arch/outline/mod.rs
+++ b/src/imp/linux_raw/arch/outline/mod.rs
@@ -14,8 +14,8 @@ mod x86;
 mod nr_last;
 
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-pub(crate) use nr_last::*;
+pub(in crate::imp::linux_raw) use nr_last::*;
 #[cfg(target_arch = "riscv64")]
-pub(crate) use riscv64::*;
+pub(in crate::imp::linux_raw) use riscv64::*;
 #[cfg(target_arch = "x86")]
-pub(crate) use x86::*;
+pub(in crate::imp::linux_raw) use x86::*;

--- a/src/imp/linux_raw/arch/outline/nr_last.rs
+++ b/src/imp/linux_raw/arch/outline/nr_last.rs
@@ -1,3 +1,5 @@
+use crate::imp::linux_raw::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
+
 // Some architectures' outline assembly code prefers to see the `nr` argument
 // last, as that lines up the syscall calling convention with the userspace
 // calling convention better.
@@ -5,56 +7,76 @@
 // First we declare the actual assembly routines with `reordered_*` names and
 // reorgered arguments.
 extern "C" {
-    fn rsix_reordered_syscall0_readonly(nr: u32) -> usize;
-    fn rsix_reordered_syscall1(a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall1_readonly(a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall1_noreturn(a0: usize, nr: u32) -> !;
-    fn rsix_reordered_syscall2(a0: usize, a1: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall2_readonly(a0: usize, a1: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall3(a0: usize, a1: usize, a2: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall3_readonly(a0: usize, a1: usize, a2: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall4(a0: usize, a1: usize, a2: usize, a3: usize, nr: u32) -> usize;
+    fn rsix_reordered_syscall0_readonly(nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1(a0: ArgReg<A0>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1_readonly(a0: ArgReg<A0>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1_noreturn(a0: ArgReg<A0>, nr: SyscallNumber) -> !;
+    fn rsix_reordered_syscall2(a0: ArgReg<A0>, a1: ArgReg<A1>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall2_readonly(
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall3(
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall3_readonly(
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall4(
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall4_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        nr: u32,
-    ) -> usize;
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        nr: u32,
-    ) -> usize;
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        nr: u32,
-    ) -> usize;
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-        nr: u32,
-    ) -> usize;
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-        nr: u32,
-    ) -> usize;
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
 }
 
 // Then we define inline wrapper functions that do the reordering.
@@ -63,110 +85,143 @@ mod reorder {
 
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
         rsix_reordered_syscall0_readonly(nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall1(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall1_readonly(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> ! {
         rsix_reordered_syscall1_noreturn(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall2(a0, a1, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall2_readonly(a0, a1, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall3(a0, a1, a2, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall3_readonly(a0, a1, a2, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall4(a0, a1, a2, a3, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall4_readonly(a0, a1, a2, a3, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall5(a0, a1, a2, a3, a4, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall5_readonly(a0, a1, a2, a3, a4, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall6(a0, a1, a2, a3, a4, a5, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall6_readonly(a0, a1, a2, a3, a4, a5, nr)
     }
 }
 
-pub(crate) use reorder::*;
+pub(in crate::imp::linux_raw) use reorder::*;

--- a/src/imp/linux_raw/arch/outline/riscv64.rs
+++ b/src/imp/linux_raw/arch/outline/riscv64.rs
@@ -1,3 +1,5 @@
+use crate::imp::linux_raw::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
+
 // riscv64's outline assembly code prefers to see the `nr` argument in a7.
 //
 // First we declare the actual assembly routines with `reordered_*` names and
@@ -11,138 +13,138 @@ extern "C" {
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall1(
-        a0: usize,
+        a0: ArgReg<A0>,
         u1: usize,
         u2: usize,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall1_readonly(
-        a0: usize,
+        a0: ArgReg<A0>,
         u1: usize,
         u2: usize,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall1_noreturn(
-        a0: usize,
+        a0: ArgReg<A0>,
         u1: usize,
         u2: usize,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
+        nr: SyscallNumber,
     ) -> !;
     fn rsix_reordered_syscall2(
-        a0: usize,
-        a1: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
         u2: usize,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall2_readonly(
-        a0: usize,
-        a1: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
         u2: usize,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall3(
-        a0: usize,
-        a1: usize,
-        a2: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall3_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
         u3: usize,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall4(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall4_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
         u4: usize,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
         u5: usize,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6_readonly(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
         u6: usize,
-        nr: u32,
-    ) -> usize;
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
 }
 
 // Then we define inline wrapper functions that do the reordering.
@@ -151,124 +153,157 @@ mod reorder {
 
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall0_readonly(u, u, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall1(a0, u, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall1_readonly(a0, u, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> ! {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall1_noreturn(a0, u, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall2(a0, a1, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall2_readonly(a0, a1, u, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall3(a0, a1, a2, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall3_readonly(a0, a1, a2, u, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall4(a0, a1, a2, a3, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall4_readonly(a0, a1, a2, a3, u, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall5(a0, a1, a2, a3, a4, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall5_readonly(a0, a1, a2, a3, a4, u, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall6(a0, a1, a2, a3, a4, a5, u, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         let u = std::mem::MaybeUninit::uninit().assume_init();
         rsix_reordered_syscall6_readonly(a0, a1, a2, a3, a4, a5, u, nr)
     }
 }
 
-pub(crate) use reorder::*;
+pub(in crate::imp::linux_raw) use reorder::*;

--- a/src/imp/linux_raw/arch/outline/x86.rs
+++ b/src/imp/linux_raw/arch/outline/x86.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use super::super::super::vdso_wrappers::SyscallType;
+use crate::imp::linux_raw::reg::{ArgReg, RetReg, SyscallNumber, A0, A1, A2, A3, A4, A5, R0};
+use crate::imp::linux_raw::vdso_wrappers::SyscallType;
 
 // x86 (using fastcall) prefers to pass a1 and a2 first, before a0, because
 // fastcall passes the first two arguments in ecx and edx, which are the second
@@ -9,56 +10,76 @@ use super::super::super::vdso_wrappers::SyscallType;
 // First we declare the actual assembly routines with `rsix_reordered_*`
 // names and reorgered arguments.
 extern "fastcall" {
-    fn rsix_reordered_syscall0_readonly(nr: u32) -> usize;
-    fn rsix_reordered_syscall1(a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall1_readonly(a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall1_noreturn(a0: usize, nr: u32) -> !;
-    fn rsix_reordered_syscall2(a1: usize, a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall2_readonly(a1: usize, a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall3(a1: usize, a2: usize, a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall3_readonly(a1: usize, a2: usize, a0: usize, nr: u32) -> usize;
-    fn rsix_reordered_syscall4(a1: usize, a2: usize, a0: usize, a3: usize, nr: u32) -> usize;
+    fn rsix_reordered_syscall0_readonly(nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1(a0: ArgReg<A0>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1_readonly(a0: ArgReg<A0>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall1_noreturn(a0: ArgReg<A0>, nr: SyscallNumber) -> !;
+    fn rsix_reordered_syscall2(a1: ArgReg<A1>, a0: ArgReg<A0>, nr: SyscallNumber) -> RetReg<R0>;
+    fn rsix_reordered_syscall2_readonly(
+        a1: ArgReg<A1>,
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall3(
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall3_readonly(
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_syscall4(
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall4_readonly(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        nr: u32,
-    ) -> usize;
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        a4: usize,
-        nr: u32,
-    ) -> usize;
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall5_readonly(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        a4: usize,
-        nr: u32,
-    ) -> usize;
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-        nr: u32,
-    ) -> usize;
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
     fn rsix_reordered_syscall6_readonly(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-        nr: u32,
-    ) -> usize;
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+        nr: SyscallNumber,
+    ) -> RetReg<R0>;
 }
 
 // Then we define inline wrapper functions that do the reordering.
@@ -67,113 +88,146 @@ mod reorder {
 
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall0_readonly(nr: u32) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
         rsix_reordered_syscall0_readonly(nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall1(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_readonly(nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall1_readonly(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall1_noreturn(nr: u32, a0: usize) -> ! {
+    pub(in crate::imp::linux_raw) unsafe fn syscall1_noreturn(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> ! {
         rsix_reordered_syscall1_noreturn(a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall2(a1, a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall2_readonly(nr: u32, a0: usize, a1: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall2_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall2_readonly(a1, a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall3(a1, a2, a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall3_readonly(nr: u32, a0: usize, a1: usize, a2: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall3_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall3_readonly(a1, a2, a0, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4(nr: u32, a0: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall4(a1, a2, a0, a3, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall4_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall4_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall4_readonly(a1, a2, a0, a3, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall5(a1, a2, a0, a3, a4, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall5_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall5_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall5_readonly(a1, a2, a0, a3, a4, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall6(a1, a2, a0, a3, a4, a5, nr)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn syscall6_readonly(
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn syscall6_readonly(
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         rsix_reordered_syscall6_readonly(a1, a2, a0, a3, a4, a5, nr)
     }
 }
 
-pub(crate) use reorder::*;
+pub(in crate::imp::linux_raw) use reorder::*;
 
 // x86 prefers to route all syscalls through the vDSO, though this isn't
 // always possible, so it also has a special form for doing the dispatch.
@@ -181,49 +235,57 @@ pub(crate) use reorder::*;
 // First we declare the actual assembly routines with `rsix_reordered_*`
 // names and reorgered arguments.
 extern "fastcall" {
-    fn rsix_reordered_indirect_syscall0(nr: u32, callee: SyscallType) -> usize;
-    fn rsix_reordered_indirect_syscall1(a0: usize, nr: u32, callee: SyscallType) -> usize;
-    fn rsix_reordered_indirect_syscall1_noreturn(a0: usize, nr: u32, callee: SyscallType) -> !;
+    fn rsix_reordered_indirect_syscall0(nr: SyscallNumber, callee: SyscallType) -> RetReg<R0>;
+    fn rsix_reordered_indirect_syscall1(
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
+        callee: SyscallType,
+    ) -> RetReg<R0>;
+    fn rsix_reordered_indirect_syscall1_noreturn(
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
+        callee: SyscallType,
+    ) -> !;
     fn rsix_reordered_indirect_syscall2(
-        a1: usize,
-        a0: usize,
-        nr: u32,
+        a1: ArgReg<A1>,
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
         callee: SyscallType,
-    ) -> usize;
+    ) -> RetReg<R0>;
     fn rsix_reordered_indirect_syscall3(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        nr: u32,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        nr: SyscallNumber,
         callee: SyscallType,
-    ) -> usize;
+    ) -> RetReg<R0>;
     fn rsix_reordered_indirect_syscall4(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        nr: u32,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        nr: SyscallNumber,
         callee: SyscallType,
-    ) -> usize;
+    ) -> RetReg<R0>;
     fn rsix_reordered_indirect_syscall5(
-        a1: usize,
-        a2: usize,
-        a0: usize,
-        a3: usize,
-        a4: usize,
-        nr: u32,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        nr: SyscallNumber,
         callee: SyscallType,
-    ) -> usize;
+    ) -> RetReg<R0>;
     fn rsix_reordered_indirect_syscall6(
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-        nr: u32,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a0: ArgReg<A0>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+        nr: SyscallNumber,
         callee: SyscallType,
-    ) -> usize;
+    ) -> RetReg<R0>;
 }
 
 // Then we define inline wrapper functions that do the reordering.
@@ -232,79 +294,90 @@ mod reorder_indirect {
 
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall0(callee: SyscallType, nr: u32) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall0(
+        callee: SyscallType,
+        nr: SyscallNumber,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall0(nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall1(callee: SyscallType, nr: u32, a0: usize) -> usize {
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall1(
+        callee: SyscallType,
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall1(a0, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall1_noreturn(callee: SyscallType, nr: u32, a0: usize) -> ! {
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall1_noreturn(
+        callee: SyscallType,
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+    ) -> ! {
         rsix_reordered_indirect_syscall1_noreturn(a0, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall2(
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall2(
         callee: SyscallType,
-        nr: u32,
-        a0: usize,
-        a1: usize,
-    ) -> usize {
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall2(a1, a0, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall3(
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall3(
         callee: SyscallType,
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-    ) -> usize {
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall3(a1, a2, a0, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall4(
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall4(
         callee: SyscallType,
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-    ) -> usize {
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall4(a1, a2, a0, a3, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall5(
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall5(
         callee: SyscallType,
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-    ) -> usize {
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall5(a1, a2, a0, a3, a4, nr, callee)
     }
     #[inline]
     #[must_use]
-    pub(crate) unsafe fn indirect_syscall6(
+    pub(in crate::imp::linux_raw) unsafe fn indirect_syscall6(
         callee: SyscallType,
-        nr: u32,
-        a0: usize,
-        a1: usize,
-        a2: usize,
-        a3: usize,
-        a4: usize,
-        a5: usize,
-    ) -> usize {
+        nr: SyscallNumber,
+        a0: ArgReg<A0>,
+        a1: ArgReg<A1>,
+        a2: ArgReg<A2>,
+        a3: ArgReg<A3>,
+        a4: ArgReg<A4>,
+        a5: ArgReg<A5>,
+    ) -> RetReg<R0> {
         rsix_reordered_indirect_syscall6(a1, a2, a0, a3, a4, a5, nr, callee)
     }
 }
 
-pub(crate) use reorder_indirect::*;
+pub(in crate::imp::linux_raw) use reorder_indirect::*;

--- a/src/imp/linux_raw/fs/dir.rs
+++ b/src/imp/linux_raw/fs/dir.rs
@@ -51,7 +51,7 @@ impl Dir {
     /// `readdir(self)`, where `None` means the end of the directory.
     pub fn read(&mut self) -> Option<io::Result<DirEntry>> {
         if let Some(next) = self.next.take() {
-            match super::super::syscalls::_seek(
+            match crate::imp::linux_raw::syscalls::_seek(
                 self.fd.as_fd(),
                 next as i64,
                 linux_raw_sys::general::SEEK_SET,
@@ -142,7 +142,8 @@ impl Dir {
         self.buf
             .resize(self.buf.capacity() + 32 * size_of::<linux_dirent64>(), 0);
         self.pos = 0;
-        let nread = match super::super::syscalls::getdents(self.fd.as_fd(), &mut self.buf) {
+        let nread = match crate::imp::linux_raw::syscalls::getdents(self.fd.as_fd(), &mut self.buf)
+        {
             Ok(nread) => nread,
             Err(err) => return Some(Err(err)),
         };

--- a/src/imp/linux_raw/io/epoll.rs
+++ b/src/imp/linux_raw/io/epoll.rs
@@ -60,7 +60,7 @@
 
 #![allow(unsafe_code)]
 
-use super::super::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
+use crate::imp::linux_raw::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
 use crate::io;
 use crate::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use bitflags::bitflags;

--- a/src/imp/linux_raw/io/mod.rs
+++ b/src/imp/linux_raw/io/mod.rs
@@ -1,5 +1,5 @@
 pub mod epoll;
-mod error;
+pub(super) mod error;
 mod poll_fd;
 mod types;
 
@@ -12,7 +12,6 @@ pub use types::{
 
 use std::os::raw::{c_int, c_uint};
 
-pub(crate) use error::{check_fd, check_result, check_void};
 pub(crate) const AT_FDCWD: c_int = linux_raw_sys::general::AT_FDCWD;
 pub(crate) const STDIN_FILENO: c_uint = linux_raw_sys::general::STDIN_FILENO;
 pub(crate) const STDOUT_FILENO: c_uint = linux_raw_sys::general::STDOUT_FILENO;

--- a/src/imp/linux_raw/mod.rs
+++ b/src/imp/linux_raw/mod.rs
@@ -1,5 +1,6 @@
 mod arch;
 mod conv;
+mod reg;
 mod vdso;
 mod vdso_wrappers;
 

--- a/src/imp/linux_raw/reg.rs
+++ b/src/imp/linux_raw/reg.rs
@@ -1,0 +1,252 @@
+//! Encapsulation for system call arguments and return values.
+//!
+//! The inline-asm and outline-asm code paths do some amount of reordering
+//! of arguments; to ensure that we don't accidentally misroute an argument
+//! or return value, we use distinct types for each argument index and
+//! return value.
+//!
+//! # Safety
+//!
+//! The `ToAsm` and `FromAsm` traits are unsafe to use; they should only be
+//! used by the syscall code which executes actual syscall machine
+//! instructions.
+
+#![allow(unsafe_code)]
+
+use crate::io::RawFd;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::os::raw::{c_int, c_uint};
+
+pub(super) trait ToAsm: private::Sealed {
+    /// Convert `self` to a `usize` ready to be passed to a syscall
+    /// machine instruction.
+    ///
+    /// # Safety
+    ///
+    /// This should be used immediately before the syscall instruction, and
+    /// the returned value shouldn't be used for any other purpose.
+    unsafe fn to_asm(self) -> usize;
+}
+
+pub(super) trait FromAsm: private::Sealed {
+    /// Convert `bits` from a value produced by a syscall machine instruction
+    /// into a `Self`.
+    ///
+    /// # Safety
+    ///
+    /// This should be used immediately after the syscall instruction, and
+    /// the operand value shouldn't be used for any other purpose.
+    unsafe fn from_asm(bits: usize) -> Self;
+}
+
+// Argument numbers.
+pub(super) struct A0 {}
+pub(super) struct A1 {}
+pub(super) struct A2 {}
+pub(super) struct A3 {}
+pub(super) struct A4 {}
+pub(super) struct A5 {}
+#[cfg(target_arch = "x86")]
+pub(super) struct SocketArg {}
+
+pub(super) trait ArgNumber: private::Sealed {}
+impl ArgNumber for A0 {}
+impl ArgNumber for A1 {}
+impl ArgNumber for A2 {}
+impl ArgNumber for A3 {}
+impl ArgNumber for A4 {}
+impl ArgNumber for A5 {}
+#[cfg(target_arch = "x86")]
+impl ArgNumber for SocketArg {}
+
+// Return value numbers.
+pub(super) struct R0 {}
+pub(super) struct R1 {}
+
+pub(super) trait RetNumber: private::Sealed {}
+impl RetNumber for R0 {}
+impl RetNumber for R1 {}
+
+/// Syscall arguments use register-sized types. We use a newtype to
+/// discourage accidental misuse of the raw integer values.
+///
+/// Note that it doesn't implement `Clone` or `Copy`; it should be used
+/// exactly once. And it has a lifetime to ensure that it doesn't outlive
+/// any resources it might be pointing to.
+#[repr(transparent)]
+pub(super) struct ArgReg<'a, Num: ArgNumber> {
+    bits: usize,
+    _phantom: PhantomData<(&'a (), Num)>,
+}
+
+impl<'a, Num: ArgNumber> ToAsm for ArgReg<'a, Num> {
+    #[inline]
+    unsafe fn to_asm(self) -> usize {
+        self.bits
+    }
+}
+
+/// Syscall return values use register-sized types. We use a newtype to
+/// discourage accidental misuse of the raw integer values.
+///
+/// Note that it doesn't implement `Clone` or `Copy`; it should be used
+/// exactly once. And it has a lifetime to ensure that it doesn't outlive
+/// any resources it might be pointing to.
+#[repr(transparent)]
+pub(super) struct RetReg<Num: RetNumber> {
+    bits: usize,
+    _phantom: PhantomData<Num>,
+}
+
+impl<Num: RetNumber> RetReg<Num> {
+    #[inline]
+    fn decode(self) -> usize {
+        debug_assert!(!(-4095..0).contains(&(self.bits as isize)));
+        self.bits
+    }
+
+    #[inline]
+    pub(super) fn decode_usize(self) -> usize {
+        self.decode()
+    }
+
+    #[inline]
+    pub(super) fn decode_raw_fd(self) -> RawFd {
+        let bits = self.decode();
+        let raw_fd = bits as RawFd;
+
+        // Converting `raw` to `RawFd` should be lossless.
+        debug_assert_eq!(raw_fd as usize, bits);
+
+        raw_fd
+    }
+
+    #[inline]
+    pub(super) fn decode_c_int(self) -> c_int {
+        let bits = self.decode();
+        let c_int_ = bits as c_int;
+
+        // Converting `raw` to `c_int` should be lossless.
+        debug_assert_eq!(c_int_ as usize, bits);
+
+        c_int_
+    }
+
+    #[inline]
+    pub(super) fn decode_c_uint(self) -> c_uint {
+        let bits = self.decode();
+        let c_uint_ = bits as c_uint;
+
+        // Converting `raw` to `c_uint` should be lossless.
+        debug_assert_eq!(c_uint_ as usize, bits);
+
+        c_uint_
+    }
+
+    #[inline]
+    pub(super) fn decode_void_star(self) -> *mut c_void {
+        self.decode() as *mut c_void
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline]
+    pub(super) fn decode_u64(self) -> u64 {
+        self.decode() as u64
+    }
+
+    #[inline]
+    pub(super) fn decode_void(self) {
+        let _ = self.decode();
+    }
+
+    #[inline]
+    pub(super) fn decode_error_code(self) -> u16 {
+        let bits = self.bits;
+        let u16_ = bits as u16;
+
+        // `raw` must be in `-4095..0`. Linux always returns errors in
+        // `-4095..0`, and we double-check it here.
+        debug_assert!((-4095..0).contains(&(u16_ as i16 as isize)));
+
+        u16_
+    }
+
+    #[inline]
+    pub(super) fn is_nonzero(&self) -> bool {
+        self.bits != 0
+    }
+
+    #[inline]
+    pub(super) fn is_negative(&self) -> bool {
+        (self.bits as isize) < 0
+    }
+
+    #[inline]
+    pub(super) fn is_in_range(&self, range: std::ops::Range<isize>) -> bool {
+        range.contains(&(self.bits as isize))
+    }
+}
+
+impl<Num: RetNumber> FromAsm for RetReg<Num> {
+    #[inline]
+    unsafe fn from_asm(bits: usize) -> Self {
+        Self {
+            bits,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub(super) struct SyscallNumber<'a> {
+    nr: usize,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> ToAsm for SyscallNumber<'a> {
+    #[inline]
+    unsafe fn to_asm(self) -> usize {
+        self.nr
+    }
+}
+
+/// Encode a system call argument as an `ArgReg`.
+#[inline]
+pub(super) fn raw_arg<'a, Num: ArgNumber>(bits: usize) -> ArgReg<'a, Num> {
+    ArgReg {
+        bits,
+        _phantom: PhantomData,
+    }
+}
+
+/// Encode a system call number (a `__NR_*` constant) as a `SyscallNumber`.
+#[inline]
+pub(super) fn nr<'a>(nr: u32) -> SyscallNumber<'a> {
+    SyscallNumber {
+        nr: nr as usize,
+        _phantom: PhantomData,
+    }
+}
+
+/// Seal our various traits using the technique documented [here].
+///
+/// [here]: https://rust-lang.github.io/api-guidelines/future-proofing.html
+mod private {
+    pub trait Sealed {}
+
+    // Implement for those same types, but no others.
+    impl<'a, Num: super::ArgNumber> Sealed for super::ArgReg<'a, Num> {}
+    impl<Num: super::RetNumber> Sealed for super::RetReg<Num> {}
+    impl<'a> Sealed for super::SyscallNumber<'a> {}
+    impl Sealed for super::A0 {}
+    impl Sealed for super::A1 {}
+    impl Sealed for super::A2 {}
+    impl Sealed for super::A3 {}
+    impl Sealed for super::A4 {}
+    impl Sealed for super::A5 {}
+    #[cfg(target_arch = "x86")]
+    impl Sealed for super::SocketArg {}
+    impl Sealed for super::R0 {}
+    impl Sealed for super::R1 {}
+}

--- a/tests/io/mmap.rs
+++ b/tests/io/mmap.rs
@@ -36,4 +36,21 @@ fn test_mmap() {
 
         munmap(addr, 8192).unwrap();
     }
+
+    let file = openat(&dir, "foo", OFlags::RDONLY, Mode::empty()).unwrap();
+    unsafe {
+        assert_eq!(
+            mmap(
+                null_mut(),
+                8192,
+                ProtFlags::READ,
+                MapFlags::PRIVATE,
+                &file,
+                u64::MAX,
+            )
+            .unwrap_err()
+            .raw_os_error(),
+            libc::EINVAL
+        );
+    }
 }


### PR DESCRIPTION
We route syscall numbers, syscall arguments, and syscall return values
through a few layers; use dedicated types for them to ensure that they
aren't misrouted.

Making these changes led to the discovery of a UB bug, with the linux_raw
pread function being declared incorrectly.