### PR TITLE
Some more OpenBSD fixes; now passes tests on OpenBSD 7.0-current.

### DIFF
--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -39,7 +39,12 @@ fn test_file() {
         rsix::io::Error::NOTDIR
     );
 
-    #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "netbsd")))]
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     rsix::fs::fadvise(&file, 0, 10, rsix::fs::Advice::Normal).unwrap();
 
     assert_eq!(

--- a/tests/fs/mknodat.rs
+++ b/tests/fs/mknodat.rs
@@ -11,8 +11,8 @@ fn test_mknodat() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = openat(&cwd(), tmp.path(), OFlags::RDONLY, Mode::empty()).unwrap();
 
-    // Create a regular file. Not supported on FreeBSD.
-    #[cfg(not(target_os = "freebsd"))]
+    // Create a regular file. Not supported on FreeBSD or OpenBSD.
+    #[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]
     {
         mknodat(&dir, "foo", Mode::IFREG, 0).unwrap();
         let stat = statat(&dir, "foo", AtFlags::empty()).unwrap();


### PR DESCRIPTION
This fixes up some last tidbits that are needed to compile and pass `cargo test` on OpenBSD 7.0-current with Rust 1.54.0.

Thanks for the work on the `rsix` end of this! I don't expect this to avoid any breakage in the future, unless there's a way to run OpenBSD on CI (there is https://github.com/cross-platform-actions/action which uses the nested-virt-on-macOS-runner trick I mentioned today but that is... not production-grade). But at least it will have been known to work at this one point :-)