### PR TITLE
Add `Uid`, `Gid`, and `Pid` wrapper types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ errno = "0.2.7"
 libc = { version = "0.2.98", features = ["extra_traits"] }
 
 [target.'cfg(all(not(rsix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.21", features = ["v5_4", "v5_11"] }
+linux-raw-sys = { version = "0.0.22", features = ["v5_4", "v5_11"] }
 
 [dev-dependencies]
 atty = "0.2.14"

--- a/src/imp/libc/process/mod.rs
+++ b/src/imp/libc/process/mod.rs
@@ -1,5 +1,5 @@
 mod types;
 
 #[cfg(not(target_os = "wasi"))]
-pub use types::EXIT_SIGNALED_SIGABRT;
+pub use types::{RawGid, RawPid, RawUid, EXIT_SIGNALED_SIGABRT};
 pub use types::{EXIT_FAILURE, EXIT_SUCCESS};

--- a/src/imp/libc/process/types.rs
+++ b/src/imp/libc/process/types.rs
@@ -4,3 +4,10 @@ pub const EXIT_SUCCESS: c_int = libc::EXIT_SUCCESS;
 pub const EXIT_FAILURE: c_int = libc::EXIT_FAILURE;
 #[cfg(not(target_os = "wasi"))]
 pub const EXIT_SIGNALED_SIGABRT: c_int = 128 + libc::SIGABRT;
+
+#[cfg(not(target_os = "wasi"))]
+pub type RawPid = libc::pid_t;
+#[cfg(not(target_os = "wasi"))]
+pub type RawGid = libc::gid_t;
+#[cfg(not(target_os = "wasi"))]
+pub type RawUid = libc::uid_t;

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -85,6 +85,8 @@ use super::rand::GetRandomFlags;
 use super::time::Timespec;
 use crate::as_ptr;
 use crate::io::{self, OwnedFd, RawFd};
+#[cfg(not(target_os = "wasi"))]
+use crate::process::{Gid, Pid, Uid};
 use errno::errno;
 use io_lifetimes::{AsFd, BorrowedFd};
 use std::cmp::min;
@@ -1969,53 +1971,71 @@ pub(crate) fn fcntl_rdadvise(fd: BorrowedFd<'_>, offset: u64, len: u64) -> io::R
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn getuid() -> u32 {
-    unsafe { libc::getuid() }
+pub(crate) fn getuid() -> Uid {
+    unsafe {
+        let uid = libc::getuid();
+        Uid::from_raw(uid)
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn geteuid() -> u32 {
-    unsafe { libc::geteuid() }
+pub(crate) fn geteuid() -> Uid {
+    unsafe {
+        let uid = libc::geteuid();
+        Uid::from_raw(uid)
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn getgid() -> u32 {
-    unsafe { libc::getgid() }
+pub(crate) fn getgid() -> Gid {
+    unsafe {
+        let gid = libc::getgid();
+        Gid::from_raw(gid)
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn getegid() -> u32 {
-    unsafe { libc::getegid() }
+pub(crate) fn getegid() -> Gid {
+    unsafe {
+        let gid = libc::getegid();
+        Gid::from_raw(gid)
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn getpid() -> u32 {
-    let pid: i32 = unsafe { libc::getpid() };
-    pid as u32
+pub(crate) fn getpid() -> Pid {
+    unsafe {
+        let pid = libc::getpid();
+        Pid::from_raw(pid)
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[must_use]
-pub(crate) fn getppid() -> u32 {
-    let pid: i32 = unsafe { libc::getppid() };
-    pid as u32
+pub(crate) fn getppid() -> Pid {
+    unsafe {
+        let pid: i32 = libc::getppid();
+        Pid::from_raw(pid)
+    }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 #[must_use]
-pub(crate) fn gettid() -> u32 {
-    let tid: i32 = unsafe { libc::gettid() };
-    tid as u32
+pub(crate) fn gettid() -> Pid {
+    unsafe {
+        let tid: i32 = libc::gettid();
+        Pid::from_raw(tid)
+    }
 }
 
 #[inline]

--- a/src/imp/linux_raw/process/mod.rs
+++ b/src/imp/linux_raw/process/mod.rs
@@ -1,3 +1,3 @@
 mod types;
 
-pub use types::{EXIT_FAILURE, EXIT_SIGNALED_SIGABRT, EXIT_SUCCESS};
+pub use types::{RawGid, RawPid, RawUid, EXIT_FAILURE, EXIT_SIGNALED_SIGABRT, EXIT_SUCCESS};

--- a/src/imp/linux_raw/process/types.rs
+++ b/src/imp/linux_raw/process/types.rs
@@ -3,3 +3,7 @@ use std::os::raw::c_int;
 pub const EXIT_SUCCESS: c_int = 0;
 pub const EXIT_FAILURE: c_int = 1;
 pub const EXIT_SIGNALED_SIGABRT: c_int = 128 + linux_raw_sys::general::SIGABRT as i32;
+
+pub type RawPid = u32;
+pub type RawGid = u32;
+pub type RawUid = u32;

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -50,6 +50,7 @@ use super::reg::{ArgReg, SocketArg};
 use super::time::{ClockId, Timespec};
 use crate::io;
 use crate::io::{OwnedFd, RawFd};
+use crate::process::{Gid, Pid, Uid};
 use crate::time::NanosleepRelativeResult;
 use io_lifetimes::{AsFd, BorrowedFd};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -2837,74 +2838,87 @@ pub(crate) unsafe fn userfaultfd(flags: UserfaultfdFlags) -> io::Result<OwnedFd>
 }
 
 #[inline]
-pub(crate) fn getpid() -> u32 {
-    let pid: i32 =
-        unsafe { ret_usize_infallible(syscall0_readonly(nr(__NR_getpid))) as __kernel_pid_t };
-    pid as u32
+pub(crate) fn getpid() -> Pid {
+    unsafe {
+        let pid: i32 = ret_usize_infallible(syscall0_readonly(nr(__NR_getpid))) as __kernel_pid_t;
+        Pid::from_raw(pid as u32)
+    }
 }
 
 #[inline]
-pub(crate) fn getppid() -> u32 {
-    let ppid: i32 =
-        unsafe { ret_usize_infallible(syscall0_readonly(nr(__NR_getppid))) as __kernel_pid_t };
-    ppid as u32
+pub(crate) fn getppid() -> Pid {
+    unsafe {
+        let ppid: i32 = ret_usize_infallible(syscall0_readonly(nr(__NR_getppid))) as __kernel_pid_t;
+        Pid::from_raw(ppid as u32)
+    }
 }
 
 #[inline]
-pub(crate) fn getgid() -> u32 {
+pub(crate) fn getgid() -> Gid {
     #[cfg(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm"))]
     unsafe {
-        (ret_usize_infallible(syscall0_readonly(nr(__NR_getgid32))) as __kernel_gid_t).into()
+        let gid: i32 =
+            (ret_usize_infallible(syscall0_readonly(nr(__NR_getgid32))) as __kernel_gid_t).into();
+        Gid::from_raw(gid as u32)
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm")))]
     unsafe {
-        ret_usize_infallible(syscall0_readonly(nr(__NR_getgid))) as __kernel_gid_t
+        let gid = ret_usize_infallible(syscall0_readonly(nr(__NR_getgid))) as __kernel_gid_t;
+        Gid::from_raw(gid)
     }
 }
 
 #[inline]
-pub(crate) fn getegid() -> u32 {
+pub(crate) fn getegid() -> Gid {
     #[cfg(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm"))]
     unsafe {
-        (ret_usize_infallible(syscall0_readonly(nr(__NR_getegid32))) as __kernel_gid_t).into()
+        let gid: i32 =
+            (ret_usize_infallible(syscall0_readonly(nr(__NR_getegid32))) as __kernel_gid_t).into();
+        Gid::from_raw(gid as u32)
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm")))]
     unsafe {
-        ret_usize_infallible(syscall0_readonly(nr(__NR_getegid))) as __kernel_gid_t
+        let gid = ret_usize_infallible(syscall0_readonly(nr(__NR_getegid))) as __kernel_gid_t;
+        Gid::from_raw(gid)
     }
 }
 
 #[inline]
-pub(crate) fn getuid() -> u32 {
+pub(crate) fn getuid() -> Uid {
     #[cfg(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm"))]
     unsafe {
-        let uid = ret_usize_infallible(syscall0_readonly(nr(__NR_getuid32))) as __kernel_uid_t;
-        uid as u32
+        let uid =
+            (ret_usize_infallible(syscall0_readonly(nr(__NR_getuid32))) as __kernel_uid_t).into();
+        Uid::from_raw(uid)
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm")))]
     unsafe {
         let uid = ret_usize_infallible(syscall0_readonly(nr(__NR_getuid))) as __kernel_uid_t;
-        uid as u32
+        Uid::from_raw(uid)
     }
 }
 
 #[inline]
-pub(crate) fn geteuid() -> u32 {
+pub(crate) fn geteuid() -> Uid {
     #[cfg(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm"))]
     unsafe {
-        (ret_usize_infallible(syscall0_readonly(nr(__NR_geteuid32))) as __kernel_uid_t).into()
+        let uid: i32 =
+            (ret_usize_infallible(syscall0_readonly(nr(__NR_geteuid32))) as __kernel_uid_t).into();
+        Uid::from_raw(uid as u32)
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "sparc", target_arch = "arm")))]
     unsafe {
-        ret_usize_infallible(syscall0_readonly(nr(__NR_geteuid))) as __kernel_uid_t
+        let uid = ret_usize_infallible(syscall0_readonly(nr(__NR_geteuid))) as __kernel_uid_t;
+        Uid::from_raw(uid)
     }
 }
 
 #[inline]
-pub(crate) fn gettid() -> u32 {
-    let tid: i32 =
-        unsafe { ret_usize_infallible(syscall0_readonly(nr(__NR_gettid))) as __kernel_pid_t };
-    tid as u32
+pub(crate) fn gettid() -> Pid {
+    unsafe {
+        let tid: i32 = ret_usize_infallible(syscall0_readonly(nr(__NR_gettid))) as __kernel_pid_t;
+        Pid::from_raw(tid as u32)
+    }
 }
 
 #[inline]

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -1,4 +1,104 @@
+//! Unix user, group, and process identiiers.
+//!
+//! # Safety
+//!
+//! The `Uid`, `Gid`, and `Uid` types can be constructed from raw integers,
+//! which is marked safe for similar reasons as [`FromRawFd::from_raw_fd`].
+//!
+//! [`FromRawFd::from_raw_fd`]: https://doc.rust-lang.org/std/os/unix/io/trait.FromRawFd.html#tymethod.from_raw_fd
+#![allow(unsafe_code)]
+
 use crate::imp;
+
+/// The raw integer value of a Unix user ID.
+pub use imp::process::RawUid;
+
+/// The raw integer value of a Unix group ID.
+pub use imp::process::RawGid;
+
+/// The raw integer value of a Unix process ID.
+pub use imp::process::RawPid;
+
+/// `uid_t`—A Unix user ID.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub struct Uid(RawUid);
+
+/// `gid_t`—A Unix group ID.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub struct Gid(RawGid);
+
+/// `pid_t`—A Unix process ID.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub struct Pid(RawPid);
+
+impl Uid {
+    /// Converts a `RawUid` into a `Uid`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be the value of a valid Unix user ID.
+    #[inline]
+    pub const unsafe fn from_raw(raw: RawUid) -> Self {
+        Self(raw)
+    }
+
+    /// Converts a `Uid` into a `RawUid`.
+    #[inline]
+    pub const fn as_raw(self) -> RawUid {
+        self.0
+    }
+
+    /// A `Uid` corresponding to the root user (uid 0).
+    pub const ROOT: Self = Self(0);
+}
+
+impl Gid {
+    /// Converts a `RawGid` into a `Gid`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be the value of a valid Unix group ID.
+    #[inline]
+    pub const unsafe fn from_raw(raw: RawGid) -> Self {
+        Self(raw)
+    }
+
+    /// Converts a `Gid` into a `RawGid`.
+    #[inline]
+    pub const fn as_raw(self) -> RawGid {
+        self.0
+    }
+
+    /// A `Gid` corresponding to the root group (gid 0).
+    pub const ROOT: Self = Self(0);
+}
+
+impl Pid {
+    /// Converts a `RawPid` into a `Pid`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be the value of a valid Unix process ID.
+    #[inline]
+    pub const unsafe fn from_raw(raw: RawPid) -> Self {
+        Self(raw)
+    }
+
+    /// Converts a `Pid` into a `RawPid`.
+    #[inline]
+    pub const fn as_raw(self) -> RawPid {
+        self.0
+    }
+
+    /// A `Pid` corresponding to no process (pid 0).
+    pub const NONE: Self = Self(0);
+
+    /// A `Pid` corresponding to the init process (pid 1).
+    pub const INIT: Self = Self(1);
+}
 
 /// `getuid()`—Returns the process' real user ID.
 ///
@@ -10,7 +110,7 @@ use crate::imp;
 /// [Linux]: https://man7.org/linux/man-pages/man2/getuid.2.html
 #[inline]
 #[must_use]
-pub fn getuid() -> u32 {
+pub fn getuid() -> Uid {
     imp::syscalls::getuid()
 }
 
@@ -24,7 +124,7 @@ pub fn getuid() -> u32 {
 /// [Linux]: https://man7.org/linux/man-pages/man2/geteuid.2.html
 #[inline]
 #[must_use]
-pub fn geteuid() -> u32 {
+pub fn geteuid() -> Uid {
     imp::syscalls::geteuid()
 }
 
@@ -38,7 +138,7 @@ pub fn geteuid() -> u32 {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getgid.2.html
 #[inline]
 #[must_use]
-pub fn getgid() -> u32 {
+pub fn getgid() -> Gid {
     imp::syscalls::getgid()
 }
 
@@ -52,7 +152,7 @@ pub fn getgid() -> u32 {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getegid.2.html
 #[inline]
 #[must_use]
-pub fn getegid() -> u32 {
+pub fn getegid() -> Gid {
     imp::syscalls::getegid()
 }
 
@@ -66,7 +166,7 @@ pub fn getegid() -> u32 {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getpid.2.html
 #[inline]
 #[must_use]
-pub fn getpid() -> u32 {
+pub fn getpid() -> Pid {
     imp::syscalls::getpid()
 }
 
@@ -80,6 +180,6 @@ pub fn getpid() -> u32 {
 /// [Linux]: https://man7.org/linux/man-pages/man2/getppid.2.html
 #[inline]
 #[must_use]
-pub fn getppid() -> u32 {
+pub fn getppid() -> Pid {
     imp::syscalls::getppid()
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -7,7 +7,9 @@ mod id;
 mod sched;
 
 #[cfg(not(target_os = "wasi"))]
-pub use id::{getegid, geteuid, getgid, getpid, getppid, getuid};
+pub use id::{
+    getegid, geteuid, getgid, getpid, getppid, getuid, Gid, Pid, RawGid, RawPid, RawUid, Uid,
+};
 pub use sched::sched_yield;
 
 /// `EXIT_SUCCESS` for use with [`exit`].

--- a/src/thread/id.rs
+++ b/src/thread/id.rs
@@ -1,4 +1,5 @@
 use crate::imp;
+use crate::process::Pid;
 
 /// `gettid()`—Returns the thread ID.
 ///
@@ -8,6 +9,6 @@ use crate::imp;
 /// [Linux]: https://man7.org/linux/man-pages/man2/gettid.2.html
 #[inline]
 #[must_use]
-pub fn gettid() -> u32 {
+pub fn gettid() -> Pid {
     imp::syscalls::gettid()
 }

--- a/tests/process/id.rs
+++ b/tests/process/id.rs
@@ -22,7 +22,7 @@ fn test_getegid() {
 
 #[test]
 fn test_getpid() {
-    assert_ne!(process::getpid(), 0);
+    assert_ne!(process::getpid(), process::Pid::NONE);
     assert_eq!(process::getpid(), process::getpid());
 }
 

--- a/tests/thread/id.rs
+++ b/tests/thread/id.rs
@@ -1,8 +1,9 @@
+use rsix::process::Pid;
 use rsix::thread;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 fn test_gettid() {
-    assert_ne!(thread::gettid(), 0);
+    assert_ne!(thread::gettid(), Pid::NONE);
     assert_eq!(thread::gettid(), thread::gettid());
 }


### PR DESCRIPTION
Inspired by [nix's similar feature], this extends the idea of hiding
plain integer values when they represent mostly meaningless identifiers.

[nix's similar feature]: https://docs.rs/nix/0.22.1/nix/unistd/struct.Pid.html