### PR TITLE
Use .init_array functions to obtain the aux vector, rather than /proc/self/auxv

### DIFF
--- a/src/imp/linux_raw/process/auxv.rs
+++ b/src/imp/linux_raw/process/auxv.rs
@@ -1,24 +1,16 @@
 //! Linux auxv support.
 //!
-//! Currently this uses /proc/self/auxv (after doing extensive checks
-//! that it is in fact procfs from the kernel). In the future, it may make
-//! sense to add a way to initialize the auxv state from the auxv passed
-//! into the process by the kernel instead.
-//!
 //! # Safety
 //!
-//! This uses `slice::from_raw_parts` to read from a file into an
-//! array of `Elf_auxv_t` records.
+//! This uses raw pointers to locate and read the kernel-provided auxv array.
 #![allow(unsafe_code)]
 #![allow(non_snake_case)]
 
-use crate::io;
-use crate::io::{pread, proc_self_auxv};
 use linux_raw_sys::general::{AT_HWCAP, AT_NULL, AT_PAGESZ, AT_SYSINFO_EHDR};
 use linux_raw_sys::v5_4::general::AT_HWCAP2;
-use once_cell::sync::OnceCell;
-use std::mem::size_of;
-use std::slice;
+use std::os::raw::c_char;
+#[cfg(target_env = "gnu")]
+use std::os::raw::c_int;
 
 #[inline]
 pub(crate) fn page_size() -> usize {
@@ -36,6 +28,14 @@ pub(in super::super) fn sysinfo_ehdr() -> usize {
     auxv().sysinfo_ehdr
 }
 
+#[inline]
+fn auxv() -> &'static Auxv {
+    // Safety: `AUXV` is initialized from the `.init_array` so it's ready
+    // before any user code calls this.
+    unsafe { &AUXV }
+}
+
+/// A struct for holding fields obtained from the kernel-provided auxv array.
 struct Auxv {
     page_size: usize,
     hwcap: usize,
@@ -43,67 +43,73 @@ struct Auxv {
     sysinfo_ehdr: usize,
 }
 
-#[inline]
-fn auxv() -> &'static Auxv {
-    static AUXV: OnceCell<Auxv> = OnceCell::new();
-    AUXV.get_or_init(initialize)
+/// Data obtained from the kernel-provided auxv array. This is initialized at
+/// program startup below.
+static mut AUXV: Auxv = Auxv {
+    page_size: 0,
+    hwcap: 0,
+    hwcap2: 0,
+    sysinfo_ehdr: 0,
+};
+
+/// GLIBC passes argc, argv, and envp to functions in .init_array, as a
+/// non-standard extension. Use priority 99 so that we run before any
+/// normal user-defined constructor functions.
+#[cfg(target_env = "gnu")]
+#[used]
+#[link_section = ".init_array.00099"]
+static INIT_ARRAY: unsafe extern "C" fn(c_int, *mut *mut c_char, *mut *mut c_char) = {
+    unsafe extern "C" fn function(_argc: c_int, _argv: *mut *mut c_char, envp: *mut *mut c_char) {
+        init_from_envp(envp);
+    }
+    function
+};
+
+/// For musl etc., assume that `__environ` is available and points to the
+/// original environment from the kernel, so we can find the auxv array in
+/// memory after it. Use priority 99 so that we run before any normal
+/// user-defined constructor functions.
+#[cfg(not(target_env = "gnu"))]
+#[used]
+#[link_section = ".init_array.00099"]
+static INIT_ARRAY: unsafe extern "C" fn() = {
+    unsafe extern "C" fn function() {
+        extern "C" {
+            static __environ: *mut *mut c_char;
+        }
+
+        init_from_envp(__environ)
+    }
+    function
+};
+
+/// # Safety
+///
+/// This must be passed a pointer to the environment variable buffer
+/// provided by the kernel, which is followed in memory by the auxv array.
+unsafe fn init_from_envp(mut envp: *mut *mut c_char) {
+    while !(*envp).is_null() {
+        envp = envp.add(1);
+    }
+    init_from_auxp(envp.add(1).cast::<_>())
 }
 
-fn initialize() -> Auxv {
-    // Some architectures need to do some setup before we can make syscalls.
-    super::super::vdso_wrappers::init_before_auxv();
-
-    // Open /proc/self/auxv and confirm it's the real thing from the kernel.
-    let fd = proc_self_auxv().unwrap();
-
-    let mut auxv = Auxv {
-        page_size: 0,
-        hwcap: 0,
-        hwcap2: 0,
-        sysinfo_ehdr: 0,
-    };
-
-    // A buffer for `Elf_auxv_t` records.
-    let mut buffer = [Elf_auxv_t {
-        a_type: 0,
-        a_val: 0,
-    }; 16];
-
-    // Safety: Use `slice::from_raw_parts` to get a byte-slice view of `buffer`.
-    let byte_slice = unsafe {
-        slice::from_raw_parts_mut(
-            (&mut buffer as *mut Elf_auxv_t).cast::<u8>(),
-            buffer.len() * size_of::<Elf_auxv_t>(),
-        )
-    };
-
-    // Iterate over the auxv records until we find AT_SYSINFO_EHDR, which
-    // points to the vDSO ELF header.
-    let mut offset = 0;
+/// # Safety
+///
+/// This must be passed a pointer to the auxv array provided by the kernel.
+unsafe fn init_from_auxp(mut auxp: *const Elf_auxv_t) {
     loop {
-        match pread(&fd, byte_slice, offset) {
-            Ok(0) => break,
-            Ok(n) => {
-                let elf_auxv_slice = &buffer[..n / size_of::<Elf_auxv_t>()];
-                for elf_auxv in elf_auxv_slice {
-                    let (a_type, a_val) = (elf_auxv.a_type, elf_auxv.a_val);
-                    match a_type as u32 {
-                        AT_PAGESZ => auxv.page_size = a_val,
-                        AT_HWCAP => auxv.hwcap = a_val,
-                        AT_HWCAP2 => auxv.hwcap2 = a_val,
-                        AT_SYSINFO_EHDR => auxv.sysinfo_ehdr = a_val,
-                        AT_NULL => break,
-                        _ => (),
-                    }
-                }
-                offset += (elf_auxv_slice.len() * size_of::<Elf_auxv_t>()) as u64;
-            }
-            Err(io::Error::INTR) => continue,
-            Err(err) => Err(err).unwrap(),
+        let Elf_auxv_t { a_type, a_val } = *auxp;
+        match a_type as _ {
+            AT_PAGESZ => AUXV.page_size = a_val,
+            AT_HWCAP => AUXV.hwcap = a_val,
+            AT_HWCAP2 => AUXV.hwcap2 = a_val,
+            AT_SYSINFO_EHDR => AUXV.sysinfo_ehdr = a_val,
+            AT_NULL => break,
+            _ => (),
         }
+        auxp = auxp.add(1);
     }
-
-    auxv
 }
 
 // ELF ABI

--- a/src/imp/linux_raw/vdso_wrappers.rs
+++ b/src/imp/linux_raw/vdso_wrappers.rs
@@ -242,16 +242,6 @@ fn init_syscall() -> SyscallType {
     unsafe { transmute(SYSCALL.load(Relaxed)) }
 }
 
-/// Initialization to perform before we attempt to open /proc/self/auxv.
-#[inline]
-pub(super) fn init_before_auxv() {
-    // On x86, we need to ensure that `SYSCALL` is minimally initialized before
-    // entering the code for /proc/self/auxv, because otherwise opening
-    // /proc/self/auxv will attempt to reenter the initialization of `SYSCALL`.
-    #[cfg(target_arch = "x86")]
-    minimal_init();
-}
-
 static mut CLOCK_GETTIME: AtomicUsize = AtomicUsize::new(0);
 #[cfg(target_arch = "x86")]
 static mut SYSCALL: AtomicUsize = AtomicUsize::new(0);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -72,7 +72,7 @@ pub use pipe::pipe;
 pub use pipe::{pipe_with, PipeFlags};
 pub use poll::{PollFd, PollFdVec, PollFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use procfs::{proc, proc_self, proc_self_fd};
+pub use procfs::proc_self_fd;
 pub use read_write::{pread, pwrite, read, readv, write, writev};
 #[cfg(not(target_os = "redox"))]
 pub use read_write::{preadv, pwritev};
@@ -81,9 +81,6 @@ pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
 pub use stdio::{stderr, stdin, stdout, take_stderr, take_stdin, take_stdout};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use userfaultfd::{userfaultfd, UserfaultfdFlags};
-
-#[cfg(all(linux_raw, any(target_os = "android", target_os = "linux")))]
-pub(crate) use procfs::proc_self_auxv;
 
 #[cfg(any(linux_raw, not(target_os = "wasi")))]
 pub use imp::io::Termios;

--- a/src/path/arg.rs
+++ b/src/path/arg.rs
@@ -49,7 +49,7 @@ pub trait Arg {
 
     /// Returns a view of this string as a maybe-owned [`CStr`].
     #[cfg(not(windows))]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>>;
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>>;
 
     /// Consumes `self` and returns a view of this string as a maybe-owned
     /// [`CStr`].
@@ -87,7 +87,7 @@ impl Arg for &str {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -140,7 +140,7 @@ impl Arg for &String {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(String::as_str(self).as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -191,7 +191,7 @@ impl Arg for String {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -244,7 +244,7 @@ impl Arg for &OsStr {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -297,7 +297,7 @@ impl Arg for &OsString {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(OsString::as_os_str(self).as_bytes())
                 .map_err(|_cstr_err| io::Error::INVAL)?,
@@ -349,7 +349,7 @@ impl Arg for OsString {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -402,7 +402,7 @@ impl Arg for &Path {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -458,7 +458,7 @@ impl Arg for &PathBuf {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(PathBuf::as_path(self).as_os_str().as_bytes())
                 .map_err(|_cstr_err| io::Error::INVAL)?,
@@ -510,7 +510,7 @@ impl Arg for PathBuf {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -566,7 +566,7 @@ impl Arg for &CStr {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
@@ -616,7 +616,7 @@ impl Arg for &CString {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Borrowed(CString::as_c_str(self)))
     }
 
@@ -664,7 +664,7 @@ impl Arg for CString {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
@@ -712,7 +712,7 @@ impl<'a> Arg for Cow<'a, str> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_ref()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -768,7 +768,7 @@ impl<'a> Arg for Cow<'a, OsStr> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -825,7 +825,7 @@ impl<'a> Arg for Cow<'a, CStr> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Borrowed(self))
     }
 
@@ -873,7 +873,7 @@ impl<'a> Arg for Component<'a> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -926,7 +926,7 @@ impl<'a> Arg for Components<'a> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_path().as_os_str().as_bytes())
                 .map_err(|_cstr_err| io::Error::INVAL)?,
@@ -981,7 +981,7 @@ impl<'a> Arg for Iter<'a> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_path().as_os_str().as_bytes())
                 .map_err(|_cstr_err| io::Error::INVAL)?,
@@ -1036,7 +1036,7 @@ impl Arg for &[u8] {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(*self).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -1089,7 +1089,7 @@ impl Arg for &Vec<u8> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_slice()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -1142,7 +1142,7 @@ impl Arg for Vec<u8> {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_slice()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -1195,7 +1195,7 @@ impl Arg for DecInt {
 
     #[cfg(not(windows))]
     #[inline]
-    fn as_c_str(&self) -> io::Result<Cow<CStr>> {
+    fn as_cow_c_str(&self) -> io::Result<Cow<CStr>> {
         Ok(Cow::Owned(
             CString::new(self.as_os_str().as_bytes()).map_err(|_cstr_err| io::Error::INVAL)?,
         ))
@@ -1231,7 +1231,7 @@ impl Arg for DecInt {
         Self: Sized,
         F: FnOnce(&CStr) -> io::Result<T>,
     {
-        with_c_str(self.as_os_str().as_bytes(), f)
+        f(self.as_c_str())
     }
 }
 

--- a/tests/fs/openat2.rs
+++ b/tests/fs/openat2.rs
@@ -12,7 +12,7 @@ fn openat2_more<Fd: AsFd, P: path::Arg>(
     mode: Mode,
     resolve: ResolveFlags,
 ) -> io::Result<OwnedFd> {
-    let path = path.as_c_str().unwrap().into_owned();
+    let path = path.as_cow_c_str().unwrap().into_owned();
     loop {
         match openat2(dirfd, &path, oflags, mode, resolve) {
             Ok(file) => return Ok(file),

--- a/tests/path/arg.rs
+++ b/tests/path/arg.rs
@@ -13,7 +13,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -28,7 +28,7 @@ fn test_arg() {
     assert_eq!("hello", Arg::as_str(&t).unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -46,7 +46,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -61,7 +61,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -79,7 +79,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -94,7 +94,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -112,7 +112,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -127,7 +127,10 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&Arg::as_c_str(&t).unwrap()));
+    assert_eq!(
+        cstr!("hello"),
+        Borrow::borrow(&Arg::as_cow_c_str(&t).unwrap())
+    );
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -145,7 +148,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -163,7 +166,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -178,7 +181,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -196,7 +199,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -214,7 +217,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -232,7 +235,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -250,7 +253,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -268,7 +271,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -286,7 +289,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -304,7 +307,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(cstr!("hello"), Borrow::borrow(&t.into_c_str().unwrap()));
     #[cfg(not(windows))]
@@ -319,7 +322,7 @@ fn test_arg() {
     assert_eq!("hello", t.as_str().unwrap());
     assert_eq!("hello".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("hello"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("hello"),
@@ -337,7 +340,8 @@ fn test_arg() {
     assert_eq!("43110", t.as_str().unwrap());
     assert_eq!("43110".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_c_str().unwrap()));
+    assert_eq!(cstr!("43110"), Borrow::borrow(&t.as_cow_c_str().unwrap()));
+    assert_eq!(cstr!("43110"), t.as_c_str());
     #[cfg(not(windows))]
     assert_eq!(
         cstr!("43110"),
@@ -363,7 +367,7 @@ fn test_invalid() {
     #[cfg(not(windows))]
     assert_eq!(
         cstr!(b"hello\xc0world"),
-        Borrow::borrow(&t.as_c_str().unwrap())
+        Borrow::borrow(&t.as_cow_c_str().unwrap())
     );
     #[cfg(not(windows))]
     assert_eq!(
@@ -388,7 +392,7 @@ fn test_embedded_nul() {
     assert_eq!("hello\0world", t.as_str().unwrap());
     assert_eq!("hello\0world".to_owned(), Arg::to_string_lossy(&t));
     #[cfg(not(windows))]
-    assert_eq!(t.as_c_str().unwrap_err(), io::Error::INVAL);
+    assert_eq!(t.as_cow_c_str().unwrap_err(), io::Error::INVAL);
     #[cfg(not(windows))]
     assert_eq!(t.clone().into_c_str().unwrap_err(), io::Error::INVAL);
     #[cfg(not(windows))]

--- a/tests/process/auxv.rs
+++ b/tests/process/auxv.rs
@@ -8,12 +8,17 @@ fn test_page_size() {
     assert_ne!(size, 0);
     assert!(size.is_power_of_two());
     assert_eq!(size, page_size());
+    assert_eq!(size, unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize });
 }
 
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_linux_hwcap() {
-    let (_hwcap, _hwcap2) = linux_hwcap();
+    let (_hwcap, hwcap2) = linux_hwcap();
 
-    // These values are architecture-defined.
+    // GLIBC seems to return a different value than `LD_SHOW_AUXV=1` reports.
+    #[cfg(not(target_env = "gnu"))]
+    assert_eq!(_hwcap, unsafe { libc::getauxval(libc::AT_HWCAP) } as usize);
+
+    assert_eq!(hwcap2, unsafe { libc::getauxval(libc::AT_HWCAP2) } as usize);
 }


### PR DESCRIPTION
This improves compatibility with qemu, where opening /proc/self/auxv one component at a time results in reading the host auxv, which is incorrect within qemu.