### PR TITLE
Drop `PollFdVec`, and just expose a `poll` function which takes a slice.

### DIFF
--- a/src/imp/linux_raw/io/poll_fd.rs
+++ b/src/imp/linux_raw/io/poll_fd.rs
@@ -67,3 +67,10 @@ impl<'fd> PollFd<'fd> {
         PollFlags::from_bits(self.revents).unwrap()
     }
 }
+
+impl<'fd> AsFd for PollFd<'fd> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -70,7 +70,7 @@ pub use owned_fd::OwnedFd;
 pub use pipe::pipe;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use pipe::{pipe_with, PipeFlags};
-pub use poll::{PollFd, PollFdVec, PollFlags};
+pub use poll::{poll, PollFd, PollFlags};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use procfs::proc_self_fd;
 pub use read_write::{pread, pwrite, read, readv, write, writev};

--- a/src/io/poll.rs
+++ b/src/io/poll.rs
@@ -1,51 +1,16 @@
 use crate::{imp, io};
-use std::vec::IntoIter;
 
 pub use imp::io::{PollFd, PollFlags};
 
-/// A [`Vec`] of `pollfd`.
+/// `poll(self.fds, timeout)`
 ///
-/// [`Vec`]: std::vec::Vec
-#[derive(Clone, Debug)]
-pub struct PollFdVec<'fd> {
-    fds: Vec<PollFd<'fd>>,
-}
-
-impl<'fd> PollFdVec<'fd> {
-    /// Construct a new empty `PollFdVec`.
-    #[inline]
-    pub const fn new() -> Self {
-        Self { fds: Vec::new() }
-    }
-
-    /// Append a fd.
-    #[inline]
-    pub fn push(&mut self, fd: PollFd<'fd>) {
-        self.fds.push(fd)
-    }
-}
-
-impl<'fd> IntoIterator for PollFdVec<'fd> {
-    type IntoIter = IntoIter<PollFd<'fd>>;
-    type Item = PollFd<'fd>;
-
-    #[inline]
-    fn into_iter(self) -> IntoIter<PollFd<'fd>> {
-        self.fds.into_iter()
-    }
-}
-
-impl<'fd> PollFdVec<'fd> {
-    /// `poll(self.fds, timeout)`
-    ///
-    /// # References
-    ///  - [POSIX]
-    ///  - [Linux]
-    ///
-    /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
-    /// [Linux]: https://man7.org/linux/man-pages/man2/poll.2.html
-    #[inline]
-    pub fn poll(&mut self, timeout: i32) -> io::Result<usize> {
-        imp::syscalls::poll(&mut self.fds, timeout)
-    }
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/poll.2.html
+#[inline]
+pub fn poll(fds: &mut [PollFd], timeout: i32) -> io::Result<usize> {
+    imp::syscalls::poll(fds, timeout)
 }


### PR DESCRIPTION
`PollFdVec` was just a wrapper around a `Vec`, so let the user do that
if they want. This makes it possible to use `poll` with a
statically-allocated buffer.