### PR TITLE
Implement `chdir`, `fchdir`, `getcwd` and `ttyname`

### DIFF
--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -1,5 +1,7 @@
+use std::ffi::OsString;
+
 use crate::imp;
-use crate::io::RawFd;
+use crate::io::{self, RawFd};
 use io_lifetimes::BorrowedFd;
 
 /// `AT_FDCWD`—Returns a handle representing the current working directory.
@@ -25,5 +27,39 @@ pub fn cwd() -> BorrowedFd<'static> {
     #[allow(unsafe_code)]
     unsafe {
         BorrowedFd::<'static>::borrow_raw_fd(at_fdcwd)
+    }
+}
+
+/// `getcwd(reuse)`
+///
+/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub fn getcwd(reuse: OsString) -> io::Result<OsString> {
+    use std::os::unix::prelude::OsStringExt;
+
+    // This code would benefit from having a better way to read into
+    // uninitialized memory, but that requires `unsafe`.
+    let mut buffer = reuse.into_vec();
+    buffer.clear();
+    buffer.resize(256, 0_u8);
+
+    loop {
+        match imp::syscalls::getcwd(&mut buffer) {
+            Err(imp::io::Error::RANGE) => buffer.resize(buffer.len() * 2, 0_u8),
+            Ok(_) => {
+                let len = buffer.iter().position(|x| *x == b'\0').unwrap();
+                buffer.resize(len, 0_u8);
+                return Ok(OsString::from_vec(buffer));
+            }
+            Err(errno) => return Err(errno),
+        }
     }
 }

--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -30,7 +30,7 @@ pub fn cwd() -> BorrowedFd<'static> {
     }
 }
 
-/// `getcwd(reuse)`
+/// `getcwd()`
 ///
 /// If `reuse` is non-empty, reuse its buffer to store the result if possible.
 ///

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -81,6 +81,8 @@ pub use constants::{Access, FdFlags, Mode, OFlags};
 pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
 pub use cwd::cwd;
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+pub use cwd::getcwd;
 #[cfg(not(target_os = "redox"))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(

--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -125,6 +125,15 @@ pub(super) fn ret_discarded_fd(raw: c_int) -> io::Result<()> {
     }
 }
 
+#[inline]
+pub(super) fn ret_discarded_char_ptr(raw: *mut c_char) -> io::Result<()> {
+    if raw.is_null() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 /// Convert a c_long returned from `syscall` to an `OwnedFd`, if valid.
 ///
 /// # Safety

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -9,7 +9,8 @@
 )))]
 use super::conv::ret_u32;
 use super::conv::{
-    borrowed_fd, no_fd, ret, ret_c_int, ret_discarded_fd, ret_off_t, ret_owned_fd, ret_ssize_t,
+    borrowed_fd, no_fd, ret, ret_c_int, ret_discarded_char_ptr, ret_discarded_fd, ret_off_t,
+    ret_owned_fd, ret_ssize_t,
 };
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use super::conv::{syscall_ret, syscall_ret_owned_fd, syscall_ret_ssize_t};
@@ -1167,6 +1168,11 @@ pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, flags: DupFlags) -> i
 pub(crate) fn dup2_with(fd: BorrowedFd<'_>, new: &OwnedFd, _flags: DupFlags) -> io::Result<()> {
     // Android 5.0 has dup3, but libc doesn't have bindings
     dup2(fd, new)
+}
+
+#[cfg(not(target_os = "wasi"))]
+pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<()> {
+    unsafe { ret_discarded_char_ptr(libc::getcwd(buf.as_mut_ptr().cast::<_>(), buf.len())) }
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -2660,9 +2660,8 @@ pub(crate) fn clock_nanosleep_absolute(id: ClockId, req: &__kernel_timespec) -> 
 }
 
 #[inline]
-pub(crate) fn getcwd(buf: &mut [c_char]) -> io::Result<usize> {
+pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<usize> {
     let (buf_addr_mut, buf_len) = slice_mut(buf);
-
     unsafe { ret_usize(syscall2(nr(__NR_getcwd), buf_addr_mut, buf_len)) }
 }
 

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -3011,6 +3011,56 @@ pub(crate) fn gettid() -> Pid {
     }
 }
 
+/// https://github.com/ifduyue/musl/blob/cfdfd5ea3ce14c6abf7fb22a531f3d99518b5a1b/src/internal/procfdname.c
+fn procfdname(mut fd: i32) -> [u8; 24] {
+    let mut buf = [0; 24];
+    let mut i = 0;
+
+    for c in "/proc/self/fd/".as_bytes() {
+        buf[i] = *c;
+        i += 1;
+    }
+
+    if fd == 0 {
+        buf[i] = '0' as u8;
+        buf[i + 1] = 0;
+    } else {
+        let mut j = fd;
+        while j != 0 {
+            j /= 10;
+            i += 1;
+        }
+
+        buf[i] = 0;
+
+        while fd != 0 {
+            i -= 1;
+            buf[i] = '0' as u8 + (fd % 10) as u8;
+            fd /= 10;
+        }
+    }
+
+    buf
+}
+
+#[inline]
+pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<()> {
+    // Check that the fd is really a tty
+    ioctl_tiocgwinsz(fd)?;
+
+    // Get the proc path of the tty
+    let procname = procfdname(fd.as_raw_fd());
+
+    // And finaly gatter the ttyname by reading the proc path
+    readlink(
+        // SATEFY: procfdname always return a nul terminated string
+        unsafe { CStr::from_bytes_with_nul_unchecked(&procname) },
+        buf,
+    )?;
+
+    Ok(())
+}
+
 #[inline]
 pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     // On error, Linux will return either `EINVAL` (2.6.32) or `ENOTTY`

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -73,7 +73,7 @@ use linux_raw_sys::general::{__NR_arm_fadvise64_64 as __NR_fadvise64_64, __NR_mm
 use linux_raw_sys::general::{
     __NR_chdir, __NR_clock_getres, __NR_clock_nanosleep, __NR_close, __NR_dup, __NR_dup3,
     __NR_epoll_create1, __NR_epoll_ctl, __NR_exit_group, __NR_faccessat, __NR_fallocate,
-    __NR_fchmod, __NR_fchmodat, __NR_fdatasync, __NR_flock, __NR_fsync, __NR_getcwd,
+    __NR_fchdir, __NR_fchmod, __NR_fchmodat, __NR_fdatasync, __NR_flock, __NR_fsync, __NR_getcwd,
     __NR_getdents64, __NR_getpid, __NR_getppid, __NR_getpriority, __NR_gettid, __NR_ioctl,
     __NR_linkat, __NR_madvise, __NR_mkdirat, __NR_mknodat, __NR_mlock, __NR_mprotect, __NR_munlock,
     __NR_munmap, __NR_nanosleep, __NR_openat, __NR_pipe2, __NR_pread64, __NR_preadv, __NR_pwrite64,
@@ -110,7 +110,8 @@ use std::convert::TryInto;
 use std::ffi::CStr;
 use std::io::{IoSlice, IoSliceMut, SeekFrom};
 use std::mem::MaybeUninit;
-use std::os::raw::{c_char, c_int, c_uint, c_void};
+use std::os::raw::{c_int, c_uint, c_void};
+use std::os::unix::prelude::AsRawFd;
 #[cfg(target_arch = "x86")]
 use {
     super::conv::x86_sys,
@@ -2668,6 +2669,11 @@ pub(crate) fn getcwd(buf: &mut [u8]) -> io::Result<usize> {
 #[inline]
 pub(crate) fn chdir(filename: &CStr) -> io::Result<()> {
     unsafe { ret(syscall1_readonly(nr(__NR_chdir), c_str(filename))) }
+}
+
+#[inline]
+pub(crate) fn fchdir(fd: BorrowedFd) -> io::Result<()> {
+    unsafe { ret(syscall1_readonly(nr(__NR_fchdir), borrowed_fd(fd))) }
 }
 
 #[inline]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -41,7 +41,7 @@ pub use fd::ioctl_fionread;
 #[cfg(not(target_os = "redox"))]
 pub use fd::is_read_write;
 pub use fd::isatty;
-#[cfg(all(libc, not(any(target_os = "fuchsia", target_os = "wasi"))))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
 pub use fd::ttyname;
 #[cfg(not(target_os = "wasi"))]
 pub use fd::{dup, dup2, dup2_with, DupFlags};

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -1,0 +1,28 @@
+use crate::io;
+use crate::{imp, path};
+#[cfg(not(target_os = "fuchsia"))]
+use io_lifetimes::AsFd;
+
+/// `chdir(path)`—Change the working directory.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/chdir.2.html
+#[inline]
+pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
+    path.into_with_c_str(|path| imp::syscalls::chdir(path))
+}
+
+/// `fchdir(fd)`—Change the working directory.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/fchdir.2.html
+#[cfg(not(target_os = "fuchsia"))]
+#[inline]
+pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::fchdir(fd)
+}

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -3,6 +3,8 @@
 use crate::imp;
 
 mod auxv;
+#[cfg(not(target_os = "wasi"))]
+mod chdir;
 mod exit;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have get[gpu]id.
 mod id;
@@ -15,6 +17,10 @@ mod uname;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use auxv::linux_hwcap;
 pub use auxv::page_size;
+#[cfg(not(target_os = "wasi"))]
+pub use chdir::chdir;
+#[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
+pub use chdir::fchdir;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use exit::exit_group;
 #[cfg(not(target_os = "wasi"))]

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -24,3 +24,5 @@ mod openat2;
 mod readdir;
 mod renameat;
 mod statfs;
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+mod working_directory;

--- a/tests/fs/working_directory.rs
+++ b/tests/fs/working_directory.rs
@@ -1,0 +1,42 @@
+use rsix::fs::{Mode, OFlags};
+use tempfile::{tempdir, TempDir};
+
+#[allow(unused)]
+fn tmpdir() -> TempDir {
+    tempdir().expect("expected to be able to create a temporary directory")
+}
+
+// Disable this test on macos because GHA as a weird system folder structure
+// that makes this test fail
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn test_changing_working_directory() {
+    use std::ffi::OsString;
+
+    let tmpdir = tmpdir();
+
+    let orig_cwd = rsix::fs::getcwd(OsString::new()).expect("get the cwd");
+    let orig_fd_cwd = rsix::fs::openat(&rsix::fs::cwd(), ".", OFlags::RDONLY, Mode::empty())
+        .expect("get a fd for the current directory");
+
+    rsix::process::chdir(tmpdir.path()).expect("changing dir to the tmp");
+    let ch1_cwd = rsix::fs::getcwd(OsString::new()).expect("get the cwd");
+
+    assert_ne!(orig_cwd, ch1_cwd, "The cwd hasn't changed!");
+    assert_eq!(
+        ch1_cwd,
+        tmpdir.path(),
+        "The cwd is not the same as the tmpdir"
+    );
+
+    #[cfg(not(target_os = "fuchsia"))]
+    rsix::process::fchdir(orig_fd_cwd).expect("changing dir to the original");
+    #[cfg(target_os = "fushcia")]
+    rsix::process::chdir(orig_cwd).expect("changing dir to the original");
+    let ch2_cwd = rsix::fs::getcwd(ch1_cwd).expect("get the cwd");
+
+    assert_eq!(
+        orig_cwd, ch2_cwd,
+        "The cwd wasn't changed back to the it's original position"
+    );
+}


### PR DESCRIPTION
This pull-request implement the following functions: `chdir`, `fchdir`, `getcwd` and `ttyname` with their unit test (expect for `ttyname`, because I don't know how to test it reliably and simply).

`getcwd` and `ttyname` use the same routine that was already present for reusing an `OsString` if possible.