### PR TITLE
Fix undefined behavior in `ttyname`.

### DIFF
--- a/examples/ttyname.rs
+++ b/examples/ttyname.rs
@@ -1,0 +1,33 @@
+use rsix::io::{self, isatty, stderr, stdin, stdout, ttyname};
+use std::ffi::OsString;
+
+fn main() -> io::Result<()> {
+    let (stdin, stdout, stderr) = unsafe { (stdin(), stdout(), stderr()) };
+    if isatty(&stdin) {
+        println!(
+            "Stdin ttyname: {}",
+            ttyname(&stdin, OsString::new())?.to_string_lossy()
+        );
+    } else {
+        println!("Stdin is not a tty");
+    }
+
+    if isatty(&stdout) {
+        println!(
+            "Stdout ttyname: {}",
+            ttyname(&stdout, OsString::new())?.to_string_lossy()
+        );
+    } else {
+        println!("Stdout is not a tty");
+    }
+
+    if isatty(&stderr) {
+        println!(
+            "Stderr ttyname: {}",
+            ttyname(&stderr, OsString::new())?.to_string_lossy()
+        );
+    } else {
+        println!("Stderr is not a tty");
+    }
+    Ok(())
+}

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -3029,8 +3029,9 @@ pub(crate) fn ttyname(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<()> {
     let r = readlinkat(proc_self_fd, DecInt::from_fd(&fd).as_c_str(), buf)?;
 
     // If the number of bytes is equal to the buffer length, truncation may
-    // have occurred. And we need one extra byte for a NUL terminator.
-    if buf.len() - r <= 1 {
+    // have occurred. This check also ensures that we have enough space for
+    // adding a NUL terminator.
+    if r == buf.len() {
         return Err(crate::io::Error::RANGE);
     }
     buf[r] = 0;


### PR DESCRIPTION
Ensure that the buffer has enough storage for us to add a
NUL-terminator, and pass the subrange of the buffer which contains a
NUL-terminated string to `CStr::from_bytes_with_nul`.

I missed these in the initial code review.

For safety, this also switches from `from_bytes_with_nul_unchecked` to
`from_bytes_with_nul` for now.
