### PR TITLE
Add an example demonstrating use of the process APIs.

### DIFF
--- a/examples/process.rs
+++ b/examples/process.rs
@@ -1,0 +1,23 @@
+use rsix::io;
+use rsix::process::*;
+
+fn main() -> io::Result<()> {
+    println!("Pid: {}", getpid().as_raw());
+    println!("Uid: {}", getuid().as_raw());
+    println!("Gid: {}", getgid().as_raw());
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    {
+        let (a, b) = linux_hwcap();
+        println!("Linux hwcap: {:#x}, {:#x}", a, b);
+    }
+    println!("Page size: {}", page_size());
+    println!("Uname: {:?}", uname());
+    println!("Process group priority: {}", getpriority_pgrp(Pid::NONE)?);
+    println!("Process priority: {}", getpriority_process(Pid::NONE)?);
+    println!("User priority: {}", getpriority_user(Uid::ROOT)?);
+    println!(
+        "Current working directory: {}",
+        getcwd(Default::default())?.to_string_lossy()
+    );
+    Ok(())
+}

--- a/src/fs/cwd.rs
+++ b/src/fs/cwd.rs
@@ -1,7 +1,5 @@
-use std::ffi::OsString;
-
 use crate::imp;
-use crate::io::{self, RawFd};
+use crate::io::RawFd;
 use io_lifetimes::BorrowedFd;
 
 /// `AT_FDCWD`—Returns a handle representing the current working directory.
@@ -27,39 +25,5 @@ pub fn cwd() -> BorrowedFd<'static> {
     #[allow(unsafe_code)]
     unsafe {
         BorrowedFd::<'static>::borrow_raw_fd(at_fdcwd)
-    }
-}
-
-/// `getcwd()`
-///
-/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
-/// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
-#[cfg(not(target_os = "wasi"))]
-#[inline]
-pub fn getcwd(reuse: OsString) -> io::Result<OsString> {
-    use std::os::unix::prelude::OsStringExt;
-
-    // This code would benefit from having a better way to read into
-    // uninitialized memory, but that requires `unsafe`.
-    let mut buffer = reuse.into_vec();
-    buffer.clear();
-    buffer.resize(256, 0_u8);
-
-    loop {
-        match imp::syscalls::getcwd(&mut buffer) {
-            Err(imp::io::Error::RANGE) => buffer.resize(buffer.len() * 2, 0_u8),
-            Ok(_) => {
-                let len = buffer.iter().position(|x| *x == b'\0').unwrap();
-                buffer.resize(len, 0_u8);
-                return Ok(OsString::from_vec(buffer));
-            }
-            Err(errno) => return Err(errno),
-        }
     }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -81,8 +81,6 @@ pub use constants::{Access, FdFlags, Mode, OFlags};
 pub use copy_file_range::copy_file_range;
 #[cfg(not(target_os = "redox"))]
 pub use cwd::cwd;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-pub use cwd::getcwd;
 #[cfg(not(target_os = "redox"))]
 pub use dir::{Dir, DirEntry};
 #[cfg(not(any(

--- a/src/process/chdir.rs
+++ b/src/process/chdir.rs
@@ -2,6 +2,8 @@ use crate::io;
 use crate::{imp, path};
 #[cfg(not(target_os = "fuchsia"))]
 use io_lifetimes::AsFd;
+#[cfg(not(target_os = "wasi"))]
+use std::ffi::OsString;
 
 /// `chdir(path)`—Change the working directory.
 ///
@@ -25,4 +27,38 @@ pub fn chdir<P: path::Arg>(path: P) -> io::Result<()> {
 pub fn fchdir<Fd: AsFd>(fd: Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     imp::syscalls::fchdir(fd)
+}
+
+/// `getcwd()`
+///
+/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/getcwd.3.html
+#[cfg(not(target_os = "wasi"))]
+#[inline]
+pub fn getcwd(reuse: OsString) -> io::Result<OsString> {
+    use std::os::unix::prelude::OsStringExt;
+
+    // This code would benefit from having a better way to read into
+    // uninitialized memory, but that requires `unsafe`.
+    let mut buffer = reuse.into_vec();
+    buffer.clear();
+    buffer.resize(256, 0_u8);
+
+    loop {
+        match imp::syscalls::getcwd(&mut buffer) {
+            Err(imp::io::Error::RANGE) => buffer.resize(buffer.len() * 2, 0_u8),
+            Ok(_) => {
+                let len = buffer.iter().position(|x| *x == b'\0').unwrap();
+                buffer.resize(len, 0_u8);
+                return Ok(OsString::from_vec(buffer));
+            }
+            Err(errno) => return Err(errno),
+        }
+    }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -21,6 +21,8 @@ pub use auxv::page_size;
 pub use chdir::chdir;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
 pub use chdir::fchdir;
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+pub use chdir::getcwd;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use exit::exit_group;
 #[cfg(not(target_os = "wasi"))]

--- a/tests/fs/main.rs
+++ b/tests/fs/main.rs
@@ -24,5 +24,3 @@ mod openat2;
 mod readdir;
 mod renameat;
 mod statfs;
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-mod working_directory;

--- a/tests/process/main.rs
+++ b/tests/process/main.rs
@@ -9,3 +9,5 @@ mod priority;
 mod sched_yield;
 #[cfg(not(target_os = "wasi"))] // WASI doesn't have uname.
 mod uname;
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+mod working_directory;

--- a/tests/process/working_directory.rs
+++ b/tests/process/working_directory.rs
@@ -15,12 +15,12 @@ fn test_changing_working_directory() {
 
     let tmpdir = tmpdir();
 
-    let orig_cwd = rsix::fs::getcwd(OsString::new()).expect("get the cwd");
+    let orig_cwd = rsix::process::getcwd(OsString::new()).expect("get the cwd");
     let orig_fd_cwd = rsix::fs::openat(&rsix::fs::cwd(), ".", OFlags::RDONLY, Mode::empty())
         .expect("get a fd for the current directory");
 
     rsix::process::chdir(tmpdir.path()).expect("changing dir to the tmp");
-    let ch1_cwd = rsix::fs::getcwd(OsString::new()).expect("get the cwd");
+    let ch1_cwd = rsix::process::getcwd(OsString::new()).expect("get the cwd");
 
     assert_ne!(orig_cwd, ch1_cwd, "The cwd hasn't changed!");
     assert_eq!(
@@ -33,7 +33,7 @@ fn test_changing_working_directory() {
     rsix::process::fchdir(orig_fd_cwd).expect("changing dir to the original");
     #[cfg(target_os = "fushcia")]
     rsix::process::chdir(orig_cwd).expect("changing dir to the original");
-    let ch2_cwd = rsix::fs::getcwd(ch1_cwd).expect("get the cwd");
+    let ch2_cwd = rsix::process::getcwd(ch1_cwd).expect("get the cwd");
 
     assert_eq!(
         orig_cwd, ch2_cwd,


### PR DESCRIPTION
Also, move `getcwd` into the `process` module, since it's reading an
attribute of the current process. This is admittadly subjective, since
`cwd()` is in `fs`, but I think it makes more sense this way because
`cwd()` is just a way to let `*at` functions behave like their non-`at`
counterparts, while `getcwd` is typically used to record the path for
later use or for use outside the process.