### PR TITLE
Add support for passing `SOCK_CLOEXEC` and `SOCK_NONBLOCK` to `socket`.

### DIFF
--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use write_sockaddr::{
 
 pub use addr::{SocketAddr, SocketAddrStorage, SocketAddrUnix};
 pub use send_recv::{RecvFlags, SendFlags};
-pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketType};
+pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -156,10 +156,26 @@ pub enum Shutdown {
 }
 
 bitflags! {
-    /// `SOCK_*` constants for [`accept`].
+    /// `SOCK_*` constants for [`accept_with`] and [`acceptfrom_with`].
     ///
-    /// [`accept`]: crate::net::accept
+    /// [`accept_with`]: crate::net::accept_with
+    /// [`acceptfrom_with`]: crate::net::acceptfrom_with
     pub struct AcceptFlags: c_int {
+        /// `SOCK_NONBLOCK`
+        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        const NONBLOCK = libc::SOCK_NONBLOCK;
+
+        /// `SOCK_CLOEXEC`
+        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        const CLOEXEC = libc::SOCK_CLOEXEC;
+    }
+}
+
+bitflags! {
+    /// `SOCK_*` constants for [`socket`].
+    ///
+    /// [`socket`]: crate::net::socket
+    pub struct SocketFlags: c_int {
         /// `SOCK_NONBLOCK`
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         const NONBLOCK = libc::SOCK_NONBLOCK;

--- a/src/imp/linux_raw/net/mod.rs
+++ b/src/imp/linux_raw/net/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use write_sockaddr::{
 
 pub use addr::{SocketAddr, SocketAddrStorage, SocketAddrUnix};
 pub use send_recv::{RecvFlags, SendFlags};
-pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketType};
+pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -117,13 +117,29 @@ pub enum Shutdown {
 }
 
 bitflags! {
-    /// `SOCK_*` constants for [`accept`].
+    /// `SOCK_*` constants for [`accept_with`] and [`acceptfrom_with`].
     ///
-    /// [`accept`]: crate::net::accept
+    /// [`accept_with`]: crate::net::accept_with
+    /// [`acceptfrom_with`]: crate::net::acceptfrom_with
     pub struct AcceptFlags: c_uint {
         /// `SOCK_NONBLOCK`
         const NONBLOCK = linux_raw_sys::general::O_NONBLOCK;
         /// `SOCK_CLOEXEC`
+        const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
+    }
+}
+
+bitflags! {
+    /// `SOCK_*` constants for [`socket`].
+    ///
+    /// [`socket`]: crate::net::socket
+    pub struct SocketFlags: c_uint {
+        /// `SOCK_NONBLOCK`
+        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        const NONBLOCK = linux_raw_sys::general::O_NONBLOCK;
+
+        /// `SOCK_CLOEXEC`
+        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,7 +13,7 @@ pub use send_recv::{
 pub use socket::{
     accept, accept_with, acceptfrom, acceptfrom_with, bind_unix, bind_v4, bind_v6, connect_unix,
     connect_v4, connect_v6, getpeername, getsockname, getsockopt_socket_type, listen, shutdown,
-    socket, AcceptFlags, AddressFamily, Protocol, Shutdown, SocketType,
+    socket, socket_with, AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
 };
 #[cfg(not(target_os = "wasi"))]
 pub use socketpair::socketpair;

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -3,7 +3,7 @@ use crate::io::{self, OwnedFd};
 use crate::net::{SocketAddr, SocketAddrUnix, SocketAddrV4, SocketAddrV6};
 use io_lifetimes::AsFd;
 
-pub use imp::net::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketType};
+pub use imp::net::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
 
 impl Default for Protocol {
     #[inline]
@@ -27,6 +27,31 @@ impl Default for Protocol {
 #[inline]
 pub fn socket(domain: AddressFamily, type_: SocketType, protocol: Protocol) -> io::Result<OwnedFd> {
     imp::syscalls::socket(domain, type_, protocol)
+}
+
+/// `socket_with(domain, type_ | flags, protocol)`—Creates a socket, with
+/// flags.
+///
+/// POSIX guarantees that `socket` will use the lowest unused file descriptor,
+/// however it is not safe in general to rely on this, as file descriptors
+/// may be unexpectedly allocated on other threads or in libraries.
+///
+/// `socket_with` is the same as `socket` but adds an additional flags operand.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
+/// [Linux]: https://man7.org/linux/man-pages/man2/socket.2.html
+#[inline]
+pub fn socket_with(
+    domain: AddressFamily,
+    type_: SocketType,
+    flags: SocketFlags,
+    protocol: Protocol,
+) -> io::Result<OwnedFd> {
+    imp::syscalls::socket_with(domain, type_, flags, protocol)
 }
 
 /// `bind(sockfd, addr, sizeof(struct sockaddr_in))`—Binds a socket to an

--- a/src/net/socketpair.rs
+++ b/src/net/socketpair.rs
@@ -1,6 +1,6 @@
 use crate::imp;
 use crate::io::{self, OwnedFd};
-use crate::net::{AcceptFlags, AddressFamily, Protocol, SocketType};
+use crate::net::{AddressFamily, Protocol, SocketFlags, SocketType};
 
 /// `socketpair(domain, type_ | accept_flags, protocol)`
 ///
@@ -14,8 +14,8 @@ use crate::net::{AcceptFlags, AddressFamily, Protocol, SocketType};
 pub fn socketpair(
     domain: AddressFamily,
     type_: SocketType,
-    accept_flags: AcceptFlags,
+    flags: SocketFlags,
     protocol: Protocol,
 ) -> io::Result<(OwnedFd, OwnedFd)> {
-    imp::syscalls::socketpair(domain, type_, accept_flags, protocol)
+    imp::syscalls::socketpair(domain, type_, flags, protocol)
 }


### PR DESCRIPTION
`socket` takes these as flags or'd into the `type` argument, similar to `socketpair`. Add a new `SocketFlags` to represent these flags, and `socket_with` to represent a socket call with flags.
