### PR TITLE
More networking support

### DIFF
--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -52,6 +52,8 @@ pub type RawAddressFamily = libc::sa_family_t;
 pub struct AddressFamily(pub(crate) RawAddressFamily);
 
 impl AddressFamily {
+    /// `AF_UNSPEC`
+    pub const UNSPEC: Self = Self(libc::AF_UNSPEC as _);
     /// `AF_INET`
     pub const INET: Self = Self(libc::AF_INET as _);
     /// `AF_INET6`
@@ -68,6 +70,236 @@ impl AddressFamily {
     /// `AF_UNIX`, aka `AF_LOCAL`
     #[doc(alias = "LOCAL")]
     pub const UNIX: Self = Self(libc::AF_UNIX as _);
+    /// `AF_AX25`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const AX25: Self = Self(libc::AF_AX25 as _);
+    /// `AF_IPX`
+    pub const IPX: Self = Self(libc::AF_IPX as _);
+    /// `AF_APPLETALK`
+    pub const APPLETALK: Self = Self(libc::AF_APPLETALK as _);
+    /// `AF_NETROM`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const NETROM: Self = Self(libc::AF_NETROM as _);
+    /// `AF_BRIDGE`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const BRIDGE: Self = Self(libc::AF_BRIDGE as _);
+    /// `AF_ATMPVC`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const ATMPVC: Self = Self(libc::AF_ATMPVC as _);
+    /// `AF_X25`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const X25: Self = Self(libc::AF_X25 as _);
+    /// `AF_ROSE`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const ROSE: Self = Self(libc::AF_ROSE as _);
+    /// `AF_DECnet`
+    #[allow(non_upper_case_globals)]
+    pub const DECnet: Self = Self(libc::AF_DECnet as _);
+    /// `AF_NETBEUI`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const NETBEUI: Self = Self(libc::AF_NETBEUI as _);
+    /// `AF_SECURITY`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const SECURITY: Self = Self(libc::AF_SECURITY as _);
+    /// `AF_KEY`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const KEY: Self = Self(libc::AF_KEY as _);
+    /// `AF_PACKET`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const PACKET: Self = Self(libc::AF_PACKET as _);
+    /// `AF_ASH`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const ASH: Self = Self(libc::AF_ASH as _);
+    /// `AF_ECONET`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const ECONET: Self = Self(libc::AF_ECONET as _);
+    /// `AF_ATMSVC`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const ATMSVC: Self = Self(libc::AF_ATMSVC as _);
+    /// `AF_RDS`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const RDS: Self = Self(libc::AF_RDS as _);
+    /// `AF_SNA`
+    pub const SNA: Self = Self(libc::AF_SNA as _);
+    /// `AF_IRDA`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const IRDA: Self = Self(libc::AF_IRDA as _);
+    /// `AF_PPPOX`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const PPPOX: Self = Self(libc::AF_PPPOX as _);
+    /// `AF_WANPIPE`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const WANPIPE: Self = Self(libc::AF_WANPIPE as _);
+    /// `AF_LLC`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const LLC: Self = Self(libc::AF_LLC as _);
+    /// `AF_CAN`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const CAN: Self = Self(libc::AF_CAN as _);
+    /// `AF_TIPC`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const TIPC: Self = Self(libc::AF_TIPC as _);
+    /// `AF_BLUETOOTH`
+    #[cfg(not(any(target_os = "ios", target_os = "macos",)))]
+    pub const BLUETOOTH: Self = Self(libc::AF_BLUETOOTH as _);
+    /// `AF_IUCV`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const IUCV: Self = Self(libc::AF_IUCV as _);
+    /// `AF_RXRPC`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const RXRPC: Self = Self(libc::AF_RXRPC as _);
+    /// `AF_ISDN`
+    pub const ISDN: Self = Self(libc::AF_ISDN as _);
+    /// `AF_PHONET`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const PHONET: Self = Self(libc::AF_PHONET as _);
+    /// `AF_IEEE802154`
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
+    pub const IEEE802154: Self = Self(libc::AF_IEEE802154 as _);
 
     /// Constructs a `AddressFamily` from a raw integer.
     #[inline]

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -52,45 +52,46 @@ impl AddressFamily {
 
 /// `IPPROTO_*`
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-#[repr(i32)]
-#[non_exhaustive]
-pub enum Protocol {
+#[repr(transparent)]
+pub struct Protocol(pub(crate) i32);
+
+impl Protocol {
     /// `IPPROTO_IP`
-    Ip = libc::IPPROTO_IP,
+    pub const IP: Self = Self(libc::IPPROTO_IP as _);
     /// `IPPROTO_ICMP`
-    Icmp = libc::IPPROTO_ICMP,
+    pub const ICMP: Self = Self(libc::IPPROTO_ICMP as _);
     /// `IPPROTO_IGMP`
-    Igmp = libc::IPPROTO_IGMP,
+    pub const IGMP: Self = Self(libc::IPPROTO_IGMP as _);
     /// `IPPROTO_IPIP`
-    Ipip = libc::IPPROTO_IPIP,
+    pub const IPIP: Self = Self(libc::IPPROTO_IPIP as _);
     /// `IPPROTO_TCP`
-    Tcp = libc::IPPROTO_TCP,
+    pub const TCP: Self = Self(libc::IPPROTO_TCP as _);
     /// `IPPROTO_EGP`
-    Egp = libc::IPPROTO_EGP,
+    pub const EGP: Self = Self(libc::IPPROTO_EGP as _);
     /// `IPPROTO_PUP`
-    Pup = libc::IPPROTO_PUP,
+    pub const PUP: Self = Self(libc::IPPROTO_PUP as _);
     /// `IPPROTO_UDP`
-    Udp = libc::IPPROTO_UDP,
+    pub const UDP: Self = Self(libc::IPPROTO_UDP as _);
     /// `IPPROTO_IDP`
-    Idp = libc::IPPROTO_IDP,
+    pub const IDP: Self = Self(libc::IPPROTO_IDP as _);
     /// `IPPROTO_TP`
-    Tp = libc::IPPROTO_TP,
+    pub const TP: Self = Self(libc::IPPROTO_TP as _);
     /// `IPPROTO_DCCP`
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "openbsd")))]
-    Dccp = libc::IPPROTO_DCCP,
+    pub const DCCP: Self = Self(libc::IPPROTO_DCCP as _);
     /// `IPPROTO_IPV6`
-    Ipv6 = libc::IPPROTO_IPV6,
+    pub const IPV6: Self = Self(libc::IPPROTO_IPV6 as _);
     /// `IPPROTO_RSVP`
-    Rsvp = libc::IPPROTO_RSVP,
+    pub const RSVP: Self = Self(libc::IPPROTO_RSVP as _);
     /// `IPPROTO_GRE`
-    Gre = libc::IPPROTO_GRE,
+    pub const GRE: Self = Self(libc::IPPROTO_GRE as _);
     /// `IPPROTO_ESP`
-    Esp = libc::IPPROTO_ESP,
+    pub const ESP: Self = Self(libc::IPPROTO_ESP as _);
     /// `IPPROTO_AH`
-    Ah = libc::IPPROTO_AH,
+    pub const AH: Self = Self(libc::IPPROTO_AH as _);
     /// `IPPROTO_MTP`
     #[cfg(not(any(target_os = "netbsd", target_os = "openbsd")))]
-    Mtp = libc::IPPROTO_MTP,
+    pub const MTP: Self = Self(libc::IPPROTO_MTP as _);
     /// `IPPROTO_BEETPH`
     #[cfg(not(any(
         target_os = "freebsd",
@@ -99,11 +100,11 @@ pub enum Protocol {
         target_os = "netbsd",
         target_os = "openbsd",
     )))]
-    Beetph = libc::IPPROTO_BEETPH,
+    pub const BEETPH: Self = Self(libc::IPPROTO_BEETPH as _);
     /// `IPPROTO_ENCAP`
-    Encap = libc::IPPROTO_ENCAP,
+    pub const ENCAP: Self = Self(libc::IPPROTO_ENCAP as _);
     /// `IPPROTO_PIM`
-    Pim = libc::IPPROTO_PIM,
+    pub const PIM: Self = Self(libc::IPPROTO_PIM as _);
     /// `IPPROTO_COMP`
     #[cfg(not(any(
         target_os = "freebsd",
@@ -112,10 +113,10 @@ pub enum Protocol {
         target_os = "netbsd",
         target_os = "openbsd",
     )))]
-    Comp = libc::IPPROTO_COMP,
+    pub const COMP: Self = Self(libc::IPPROTO_COMP as _);
     /// `IPPROTO_SCTP`
     #[cfg(not(target_os = "openbsd"))]
-    Sctp = libc::IPPROTO_SCTP,
+    pub const SCTP: Self = Self(libc::IPPROTO_SCTP as _);
     /// `IPPROTO_UDPLITE`
     #[cfg(not(any(
         target_os = "ios",
@@ -123,12 +124,12 @@ pub enum Protocol {
         target_os = "netbsd",
         target_os = "openbsd"
     )))]
-    Udplite = libc::IPPROTO_UDPLITE,
+    pub const UDPLITE: Self = Self(libc::IPPROTO_UDPLITE as _);
     /// `IPPROTO_MPLS`
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "netbsd")))]
-    Mpls = libc::IPPROTO_MPLS,
+    pub const MPLS: Self = Self(libc::IPPROTO_MPLS as _);
     /// `IPPROTO_RAW`
-    Raw = libc::IPPROTO_RAW,
+    pub const RAW: Self = Self(libc::IPPROTO_RAW as _);
     /// `IPPROTO_MPTCP`
     #[cfg(not(any(
         target_os = "android",
@@ -140,15 +141,15 @@ pub enum Protocol {
         target_os = "netbsd",
         target_os = "openbsd",
     )))]
-    Mptcp = libc::IPPROTO_MPTCP,
+    pub const MPTCP: Self = Self(libc::IPPROTO_MPTCP as _);
     /// `IPPROTO_FRAGMENT`
-    Fragment = libc::IPPROTO_FRAGMENT,
+    pub const FRAGMENT: Self = Self(libc::IPPROTO_FRAGMENT as _);
     /// `IPPROTO_ICMPV6`
-    Icmpv6 = libc::IPPROTO_ICMPV6,
+    pub const ICMPV6: Self = Self(libc::IPPROTO_ICMPV6 as _);
     /// `IPPROTO_MH`
-    Mh = libc::IPPROTO_MH,
+    pub const MH: Self = Self(libc::IPPROTO_MH as _);
     /// `IPPROTO_ROUTING`
-    Routing = libc::IPPROTO_ROUTING,
+    pub const ROUTING: Self = Self(libc::IPPROTO_ROUTING as _);
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -147,6 +147,12 @@ impl Protocol {
     /// `IPPROTO_ICMPV6`
     pub const ICMPV6: Self = Self(libc::IPPROTO_ICMPV6 as _);
     /// `IPPROTO_MH`
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )))]
     pub const MH: Self = Self(libc::IPPROTO_MH as _);
     /// `IPPROTO_ROUTING`
     pub const ROUTING: Self = Self(libc::IPPROTO_ROUTING as _);

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -1,12 +1,16 @@
 use bitflags::bitflags;
 use libc::c_int;
 
+/// A type for holding raw integer socket types.
+#[doc(hidden)]
+pub type RawSocketType = u32;
+
 /// `SOCK_*` constants for [`socket`].
 ///
 /// [`socket`]: crate::net::socket
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct SocketType(pub(crate) u32);
+pub struct SocketType(pub(crate) RawSocketType);
 
 #[rustfmt::skip]
 impl SocketType {
@@ -24,12 +28,28 @@ impl SocketType {
 
     /// `SOCK_RDM`
     pub const RDM: Self = Self(libc::SOCK_RDM as u32);
+
+    /// Constructs a `SocketType` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawSocketType) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `SocketType`.
+    #[inline]
+    pub fn as_raw(self) -> RawSocketType {
+        self.0
+    }
 }
+
+/// A type for holding raw integer address families.
+#[doc(hidden)]
+pub type RawAddressFamily = libc::sa_family_t;
 
 /// `AF_*` constants.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct AddressFamily(pub(crate) libc::sa_family_t);
+pub struct AddressFamily(pub(crate) RawAddressFamily);
 
 impl AddressFamily {
     /// `AF_INET`
@@ -48,12 +68,28 @@ impl AddressFamily {
     /// `AF_UNIX`, aka `AF_LOCAL`
     #[doc(alias = "LOCAL")]
     pub const UNIX: Self = Self(libc::AF_UNIX as _);
+
+    /// Constructs a `AddressFamily` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawAddressFamily) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `AddressFamily`.
+    #[inline]
+    pub fn as_raw(self) -> RawAddressFamily {
+        self.0
+    }
 }
+
+/// A type for holding raw integer protocols.
+#[doc(hidden)]
+pub type RawProtocol = i32;
 
 /// `IPPROTO_*`
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct Protocol(pub(crate) i32);
+pub struct Protocol(pub(crate) RawProtocol);
 
 impl Protocol {
     /// `IPPROTO_IP`
@@ -156,6 +192,18 @@ impl Protocol {
     pub const MH: Self = Self(libc::IPPROTO_MH as _);
     /// `IPPROTO_ROUTING`
     pub const ROUTING: Self = Self(libc::IPPROTO_ROUTING as _);
+
+    /// Constructs a `Protocol` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawProtocol) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `Protocol`.
+    #[inline]
+    pub fn as_raw(self) -> RawProtocol {
+        self.0
+    }
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -141,6 +141,14 @@ pub enum Protocol {
         target_os = "openbsd",
     )))]
     Mptcp = libc::IPPROTO_MPTCP,
+    /// `IPPROTO_FRAGMENT`
+    Fragment = libc::IPPROTO_FRAGMENT,
+    /// `IPPROTO_ICMPV6`
+    Icmpv6 = libc::IPPROTO_ICMPV6,
+    /// `IPPROTO_MH`
+    Mh = libc::IPPROTO_MH,
+    /// `IPPROTO_ROUTING`
+    Routing = libc::IPPROTO_ROUTING,
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -1514,7 +1514,7 @@ pub(crate) fn socket(
         ret_owned_fd(libc::socket(
             domain.0 as c_int,
             type_.0 as c_int,
-            protocol as c_int,
+            protocol.0,
         ))
     }
 }
@@ -1530,7 +1530,7 @@ pub(crate) fn socket_with(
         ret_owned_fd(libc::socket(
             domain.0 as c_int,
             type_.0 as c_int | flags.bits(),
-            protocol as c_int,
+            protocol.0,
         ))
     }
 }
@@ -1758,7 +1758,7 @@ pub(crate) fn socketpair(
         ret(libc::socketpair(
             domain.0 as c_int,
             type_.0 as c_int | flags.bits(),
-            protocol as c_int,
+            protocol.0,
             fds.as_mut_ptr().cast::<c_int>(),
         ))?;
 

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -1,12 +1,16 @@
 use bitflags::bitflags;
 use std::os::raw::c_uint;
 
+/// A type for holding raw integer socket types.
+#[doc(hidden)]
+pub type RawSocketType = u32;
+
 /// `SOCK_*` constants for [`socket`].
 ///
 /// [`socket`]: crate::net::socket
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct SocketType(pub(crate) u32);
+pub struct SocketType(pub(crate) RawSocketType);
 
 #[rustfmt::skip]
 impl SocketType {
@@ -24,12 +28,28 @@ impl SocketType {
 
     /// `SOCK_RDM`
     pub const RDM: Self = Self(linux_raw_sys::general::SOCK_RDM);
+
+    /// Constructs a `SocketType` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawSocketType) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `SocketType`.
+    #[inline]
+    pub fn as_raw(self) -> RawSocketType {
+        self.0
+    }
 }
+
+/// A type for holding raw integer address families.
+#[doc(hidden)]
+pub type RawAddressFamily = linux_raw_sys::general::__kernel_sa_family_t;
 
 /// `AF_*` constants.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct AddressFamily(pub(crate) linux_raw_sys::general::__kernel_sa_family_t);
+pub struct AddressFamily(pub(crate) RawAddressFamily);
 
 impl AddressFamily {
     /// `AF_INET`
@@ -41,12 +61,28 @@ impl AddressFamily {
     /// `AF_UNIX`, aka `AF_LOCAL`
     #[doc(alias = "LOCAL")]
     pub const UNIX: Self = Self(linux_raw_sys::general::AF_UNIX as _);
+
+    /// Constructs a `AddressFamily` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawAddressFamily) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `AddressFamily`.
+    #[inline]
+    pub fn as_raw(self) -> RawAddressFamily {
+        self.0
+    }
 }
+
+/// A type for holding raw integer protocols.
+#[doc(hidden)]
+pub type RawProtocol = u32;
 
 /// `IPPROTO_*`
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct Protocol(pub(crate) u32);
+pub struct Protocol(pub(crate) RawProtocol);
 
 impl Protocol {
     /// `IPPROTO_IP`
@@ -111,6 +147,18 @@ impl Protocol {
     pub const MH: Self = Self(linux_raw_sys::general::IPPROTO_MH as _);
     /// `IPPROTO_ROUTING`
     pub const ROUTING: Self = Self(linux_raw_sys::general::IPPROTO_ROUTING as _);
+
+    /// Constructs a `Protocol` from a raw integer.
+    #[inline]
+    pub fn from_raw(raw: RawProtocol) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw integer for this `Protocol`.
+    #[inline]
+    pub fn as_raw(self) -> RawProtocol {
+        self.0
+    }
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -102,6 +102,14 @@ pub enum Protocol {
     Raw = linux_raw_sys::general::IPPROTO_RAW as u32,
     /// `IPPROTO_MPTCP`
     Mptcp = linux_raw_sys::v5_11::general::IPPROTO_MPTCP as u32,
+    /// `IPPROTO_FRAGMENT`
+    Fragment = linux_raw_sys::general::IPPROTO_FRAGMENT as u32,
+    /// `IPPROTO_ICMPV6`
+    Icmpv6 = linux_raw_sys::general::IPPROTO_ICMPV6 as u32,
+    /// `IPPROTO_MH`
+    Mh = linux_raw_sys::general::IPPROTO_MH as u32,
+    /// `IPPROTO_ROUTING`
+    Routing = linux_raw_sys::general::IPPROTO_ROUTING as u32,
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -52,6 +52,8 @@ pub type RawAddressFamily = linux_raw_sys::general::__kernel_sa_family_t;
 pub struct AddressFamily(pub(crate) RawAddressFamily);
 
 impl AddressFamily {
+    /// `AF_UNSPEC`
+    pub const UNSPEC: Self = Self(linux_raw_sys::general::AF_UNSPEC as _);
     /// `AF_INET`
     pub const INET: Self = Self(linux_raw_sys::general::AF_INET as _);
     /// `AF_INET6`
@@ -61,6 +63,67 @@ impl AddressFamily {
     /// `AF_UNIX`, aka `AF_LOCAL`
     #[doc(alias = "LOCAL")]
     pub const UNIX: Self = Self(linux_raw_sys::general::AF_UNIX as _);
+    /// `AF_AX25`
+    pub const AX25: Self = Self(linux_raw_sys::general::AF_AX25 as _);
+    /// `AF_IPX`
+    pub const IPX: Self = Self(linux_raw_sys::general::AF_IPX as _);
+    /// `AF_APPLETALK`
+    pub const APPLETALK: Self = Self(linux_raw_sys::general::AF_APPLETALK as _);
+    /// `AF_NETROM`
+    pub const NETROM: Self = Self(linux_raw_sys::general::AF_NETROM as _);
+    /// `AF_BRIDGE`
+    pub const BRIDGE: Self = Self(linux_raw_sys::general::AF_BRIDGE as _);
+    /// `AF_ATMPVC`
+    pub const ATMPVC: Self = Self(linux_raw_sys::general::AF_ATMPVC as _);
+    /// `AF_X25`
+    pub const X25: Self = Self(linux_raw_sys::general::AF_X25 as _);
+    /// `AF_ROSE`
+    pub const ROSE: Self = Self(linux_raw_sys::general::AF_ROSE as _);
+    /// `AF_DECnet`
+    #[allow(non_upper_case_globals)]
+    pub const DECnet: Self = Self(linux_raw_sys::general::AF_DECnet as _);
+    /// `AF_NETBEUI`
+    pub const NETBEUI: Self = Self(linux_raw_sys::general::AF_NETBEUI as _);
+    /// `AF_SECURITY`
+    pub const SECURITY: Self = Self(linux_raw_sys::general::AF_SECURITY as _);
+    /// `AF_KEY`
+    pub const KEY: Self = Self(linux_raw_sys::general::AF_KEY as _);
+    /// `AF_PACKET`
+    pub const PACKET: Self = Self(linux_raw_sys::general::AF_PACKET as _);
+    /// `AF_ASH`
+    pub const ASH: Self = Self(linux_raw_sys::general::AF_ASH as _);
+    /// `AF_ECONET`
+    pub const ECONET: Self = Self(linux_raw_sys::general::AF_ECONET as _);
+    /// `AF_ATMSVC`
+    pub const ATMSVC: Self = Self(linux_raw_sys::general::AF_ATMSVC as _);
+    /// `AF_RDS`
+    pub const RDS: Self = Self(linux_raw_sys::general::AF_RDS as _);
+    /// `AF_SNA`
+    pub const SNA: Self = Self(linux_raw_sys::general::AF_SNA as _);
+    /// `AF_IRDA`
+    pub const IRDA: Self = Self(linux_raw_sys::general::AF_IRDA as _);
+    /// `AF_PPPOX`
+    pub const PPPOX: Self = Self(linux_raw_sys::general::AF_PPPOX as _);
+    /// `AF_WANPIPE`
+    pub const WANPIPE: Self = Self(linux_raw_sys::general::AF_WANPIPE as _);
+    /// `AF_LLC`
+    pub const LLC: Self = Self(linux_raw_sys::general::AF_LLC as _);
+    /// `AF_CAN`
+    pub const CAN: Self = Self(linux_raw_sys::general::AF_CAN as _);
+    /// `AF_TIPC`
+    pub const TIPC: Self = Self(linux_raw_sys::general::AF_TIPC as _);
+    /// `AF_BLUETOOTH`
+    pub const BLUETOOTH: Self = Self(linux_raw_sys::general::AF_BLUETOOTH as _);
+    /// `AF_IUCV`
+    pub const IUCV: Self = Self(linux_raw_sys::general::AF_IUCV as _);
+    /// `AF_RXRPC`
+    pub const RXRPC: Self = Self(linux_raw_sys::general::AF_RXRPC as _);
+    /// `AF_ISDN`
+    pub const ISDN: Self = Self(linux_raw_sys::general::AF_ISDN as _);
+    /// `AF_PHONET`
+    pub const PHONET: Self = Self(linux_raw_sys::general::AF_PHONET as _);
+    /// `AF_IEEE802154`
+    pub const IEEE802154: Self = Self(linux_raw_sys::general::AF_IEEE802154 as _);
 
     /// Constructs a `AddressFamily` from a raw integer.
     #[inline]

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -45,71 +45,72 @@ impl AddressFamily {
 
 /// `IPPROTO_*`
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-#[repr(u32)]
-#[non_exhaustive]
-pub enum Protocol {
+#[repr(transparent)]
+pub struct Protocol(pub(crate) u32);
+
+impl Protocol {
     /// `IPPROTO_IP`
-    Ip = linux_raw_sys::general::IPPROTO_IP as u32,
+    pub const IP: Self = Self(linux_raw_sys::general::IPPROTO_IP as _);
     /// `IPPROTO_ICMP`
-    Icmp = linux_raw_sys::general::IPPROTO_ICMP as u32,
+    pub const ICMP: Self = Self(linux_raw_sys::general::IPPROTO_ICMP as _);
     /// `IPPROTO_IGMP`
-    Igmp = linux_raw_sys::general::IPPROTO_IGMP as u32,
+    pub const IGMP: Self = Self(linux_raw_sys::general::IPPROTO_IGMP as _);
     /// `IPPROTO_IPIP`
-    Ipip = linux_raw_sys::general::IPPROTO_IPIP as u32,
+    pub const IPIP: Self = Self(linux_raw_sys::general::IPPROTO_IPIP as _);
     /// `IPPROTO_TCP`
-    Tcp = linux_raw_sys::general::IPPROTO_TCP as u32,
+    pub const TCP: Self = Self(linux_raw_sys::general::IPPROTO_TCP as _);
     /// `IPPROTO_EGP`
-    Egp = linux_raw_sys::general::IPPROTO_EGP as u32,
+    pub const EGP: Self = Self(linux_raw_sys::general::IPPROTO_EGP as _);
     /// `IPPROTO_PUP`
-    Pup = linux_raw_sys::general::IPPROTO_PUP as u32,
+    pub const PUP: Self = Self(linux_raw_sys::general::IPPROTO_PUP as _);
     /// `IPPROTO_UDP`
-    Udp = linux_raw_sys::general::IPPROTO_UDP as u32,
+    pub const UDP: Self = Self(linux_raw_sys::general::IPPROTO_UDP as _);
     /// `IPPROTO_IDP`
-    Idp = linux_raw_sys::general::IPPROTO_IDP as u32,
+    pub const IDP: Self = Self(linux_raw_sys::general::IPPROTO_IDP as _);
     /// `IPPROTO_TP`
-    Tp = linux_raw_sys::v5_4::general::IPPROTO_TP as u32,
+    pub const TP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_TP as _);
     /// `IPPROTO_DCCP`
-    Dccp = linux_raw_sys::general::IPPROTO_DCCP as u32,
+    pub const DCCP: Self = Self(linux_raw_sys::general::IPPROTO_DCCP as _);
     /// `IPPROTO_IPV6`
-    Ipv6 = linux_raw_sys::general::IPPROTO_IPV6 as u32,
+    pub const IPV6: Self = Self(linux_raw_sys::general::IPPROTO_IPV6 as _);
     /// `IPPROTO_RSVP`
-    Rsvp = linux_raw_sys::general::IPPROTO_RSVP as u32,
+    pub const RSVP: Self = Self(linux_raw_sys::general::IPPROTO_RSVP as _);
     /// `IPPROTO_GRE`
-    Gre = linux_raw_sys::general::IPPROTO_GRE as u32,
+    pub const GRE: Self = Self(linux_raw_sys::general::IPPROTO_GRE as _);
     /// `IPPROTO_ESP`
-    Esp = linux_raw_sys::general::IPPROTO_ESP as u32,
+    pub const ESP: Self = Self(linux_raw_sys::general::IPPROTO_ESP as _);
     /// `IPPROTO_AH`
-    Ah = linux_raw_sys::general::IPPROTO_AH as u32,
+    pub const AH: Self = Self(linux_raw_sys::general::IPPROTO_AH as _);
     /// `IPPROTO_MTP`
-    Mtp = linux_raw_sys::v5_4::general::IPPROTO_MTP as u32,
+    pub const MTP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_MTP as _);
     /// `IPPROTO_BEETPH`
-    Beetph = linux_raw_sys::general::IPPROTO_BEETPH as u32,
+    pub const BEETPH: Self = Self(linux_raw_sys::general::IPPROTO_BEETPH as _);
     /// `IPPROTO_ENCAP`
-    Encap = linux_raw_sys::v5_4::general::IPPROTO_ENCAP as u32,
+    pub const ENCAP: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_ENCAP as _);
     /// `IPPROTO_PIM`
-    Pim = linux_raw_sys::general::IPPROTO_PIM as u32,
+    pub const PIM: Self = Self(linux_raw_sys::general::IPPROTO_PIM as _);
     /// `IPPROTO_COMP`
-    Comp = linux_raw_sys::general::IPPROTO_COMP as u32,
+    pub const COMP: Self = Self(linux_raw_sys::general::IPPROTO_COMP as _);
     /// `IPPROTO_SCTP`
-    Sctp = linux_raw_sys::general::IPPROTO_SCTP as u32,
+    pub const SCTP: Self = Self(linux_raw_sys::general::IPPROTO_SCTP as _);
     /// `IPPROTO_UDPLITE`
-    Udplite = linux_raw_sys::general::IPPROTO_UDPLITE as u32,
+    pub const UDPLITE: Self = Self(linux_raw_sys::general::IPPROTO_UDPLITE as _);
     /// `IPPROTO_MPLS`
-    Mpls = linux_raw_sys::v5_4::general::IPPROTO_MPLS as u32,
+    pub const MPLS: Self = Self(linux_raw_sys::v5_4::general::IPPROTO_MPLS as _);
     /// `IPPROTO_ETHERNET`
-    Ethernet = linux_raw_sys::v5_11::general::IPPROTO_ETHERNET as u32,
+    pub const ETHERNET: Self = Self(linux_raw_sys::v5_11::general::IPPROTO_ETHERNET as _);
     /// `IPPROTO_RAW`
-    Raw = linux_raw_sys::general::IPPROTO_RAW as u32,
+    pub const RAW: Self = Self(linux_raw_sys::general::IPPROTO_RAW as _);
     /// `IPPROTO_MPTCP`
-    Mptcp = linux_raw_sys::v5_11::general::IPPROTO_MPTCP as u32,
+    pub const MPTCP: Self = Self(linux_raw_sys::v5_11::general::IPPROTO_MPTCP as _);
     /// `IPPROTO_FRAGMENT`
-    Fragment = linux_raw_sys::general::IPPROTO_FRAGMENT as u32,
+    pub const FRAGMENT: Self = Self(linux_raw_sys::general::IPPROTO_FRAGMENT as _);
     /// `IPPROTO_ICMPV6`
-    Icmpv6 = linux_raw_sys::general::IPPROTO_ICMPV6 as u32,
+    pub const ICMPV6: Self = Self(linux_raw_sys::general::IPPROTO_ICMPV6 as _);
     /// `IPPROTO_MH`
-    Mh = linux_raw_sys::general::IPPROTO_MH as u32,
+    pub const MH: Self = Self(linux_raw_sys::general::IPPROTO_MH as _);
     /// `IPPROTO_ROUTING`
-    Routing = linux_raw_sys::general::IPPROTO_ROUTING as u32,
+    pub const ROUTING: Self = Self(linux_raw_sys::general::IPPROTO_ROUTING as _);
 }
 
 /// `SHUT_*` constants for [`shutdown`].

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -1516,7 +1516,7 @@ pub(crate) fn socket(
             nr(__NR_socket),
             c_uint(family.0.into()),
             c_uint(type_.0),
-            c_uint(protocol as u32),
+            c_uint(protocol.0),
         ))
     }
     #[cfg(target_arch = "x86")]
@@ -1527,7 +1527,7 @@ pub(crate) fn socket(
             slice_just_addr::<ArgReg<SocketArg>, _>(&[
                 c_uint(family.0.into()),
                 c_uint(type_.0),
-                c_uint(protocol as u32),
+                c_uint(protocol.0),
             ]),
         ))
     }
@@ -1546,7 +1546,7 @@ pub(crate) fn socket_with(
             nr(__NR_socket),
             c_uint(family.0.into()),
             c_uint(type_.0 | flags.bits()),
-            c_uint(protocol as u32),
+            c_uint(protocol.0),
         ))
     }
     #[cfg(target_arch = "x86")]
@@ -1557,7 +1557,7 @@ pub(crate) fn socket_with(
             slice_just_addr::<ArgReg<SocketArg>, _>(&[
                 c_uint(family.0.into()),
                 c_uint(type_.0 | flags.bits()),
-                c_uint(protocol as u32),
+                c_uint(protocol.0),
             ]),
         ))
     }
@@ -1577,7 +1577,7 @@ pub(crate) fn socketpair(
             nr(__NR_socketpair),
             c_uint(family.0.into()),
             c_uint(type_.0 | flags.bits()),
-            c_uint(protocol as c_uint),
+            c_uint(protocol.0),
             out(&mut result),
         ))
         .map(|()| {
@@ -1594,7 +1594,7 @@ pub(crate) fn socketpair(
             slice_just_addr::<ArgReg<SocketArg>, _>(&[
                 c_uint(family.0.into()),
                 c_uint(type_.0 | flags.bits()),
-                c_uint(protocol as u32),
+                c_uint(protocol.0),
                 out(&mut result),
             ]),
         ))

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -8,7 +8,7 @@ pub use imp::net::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, 
 impl Default for Protocol {
     #[inline]
     fn default() -> Self {
-        Self::Ip
+        Self::IP
     }
 }
 

--- a/tests/process/working_directory.rs
+++ b/tests/process/working_directory.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use rsix::fs::{Mode, OFlags};
 use tempfile::{tempdir, TempDir};
 


### PR DESCRIPTION
 - Define more protocol and address family constants
 - Convert `Protocol` to a newtype away from an `enum`, to allow storing unknown values.
 - Add `from_raw` and `to_raw` functions to aid interop with other APIs
