### PR TITLE
Implement several getsockopt and setsockopt functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ errno = "0.2.7"
 libc = { version = "0.2.98", features = ["extra_traits"] }
 
 [target.'cfg(all(not(rsix_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.24", features = ["v5_4", "v5_11"] }
+linux-raw-sys = { version = "0.0.26", features = ["v5_4", "v5_11"] }
 
 [dev-dependencies]
 atty = "0.2.14"

--- a/src/imp/libc/net/mod.rs
+++ b/src/imp/libc/net/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use write_sockaddr::{
 
 pub use addr::{SocketAddr, SocketAddrStorage, SocketAddrUnix};
 pub use send_recv::{RecvFlags, SendFlags};
-pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
+pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType, Timeout};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/imp/libc/net/types.rs
+++ b/src/imp/libc/net/types.rs
@@ -484,3 +484,17 @@ bitflags! {
         const CLOEXEC = libc::SOCK_CLOEXEC;
     }
 }
+
+/// Timeout identifier for use with [`set_socket_timeout`] and
+/// [`get_socket_timeout`].
+///
+/// [`set_socket_timeout`]: crate::net::sockopt::set_socket_timeout.
+/// [`get_socket_timeout`]: crate::net::sockopt::get_socket_timeout.
+#[repr(i32)]
+pub enum Timeout {
+    /// `SO_RCVTIMEO`—Timeout for receiving.
+    Recv = libc::SO_RCVTIMEO,
+
+    /// `SO_SNDTIMEO`—Timeout for sending.
+    Send = libc::SO_SNDTIMEO,
+}

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -1729,27 +1729,6 @@ pub(crate) fn shutdown(sockfd: BorrowedFd<'_>, how: Shutdown) -> io::Result<()> 
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
-pub(crate) fn getsockopt_socket_type(fd: BorrowedFd<'_>) -> io::Result<SocketType> {
-    let mut buffer = MaybeUninit::<SocketType>::uninit();
-    let mut out_len = size_of::<SocketType>() as libc::socklen_t;
-    unsafe {
-        ret(libc::getsockopt(
-            borrowed_fd(fd),
-            libc::SOL_SOCKET,
-            libc::SO_TYPE,
-            buffer.as_mut_ptr().cast::<libc::c_void>(),
-            &mut out_len,
-        ))?;
-        assert_eq!(
-            out_len as usize,
-            size_of::<SocketType>(),
-            "unexpected SocketType size"
-        );
-        Ok(buffer.assume_init())
-    }
-}
-
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 pub(crate) fn getsockname(sockfd: BorrowedFd<'_>) -> io::Result<SocketAddr> {
     unsafe {
         let mut storage = MaybeUninit::<libc::sockaddr_storage>::uninit();
@@ -2245,5 +2224,403 @@ pub(crate) fn setpriority_process(pid: Pid, priority: i32) -> io::Result<()> {
             pid.as_raw() as _,
             priority,
         ))
+    }
+}
+
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+pub(crate) mod sockopt {
+    use crate::net::sockopt::Timeout;
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    use crate::net::Ipv6Addr;
+    use crate::net::{Ipv4Addr, SocketType};
+    use crate::{as_mut_ptr, io};
+    use io_lifetimes::BorrowedFd;
+    use std::convert::TryInto;
+    use std::os::raw::{c_int, c_uint};
+    use std::time::Duration;
+
+    #[inline]
+    fn getsockopt<T>(fd: BorrowedFd<'_>, level: i32, optname: i32) -> io::Result<T> {
+        use super::*;
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            let mut optlen = std::mem::size_of::<T>().try_into().unwrap();
+            ret(libc::getsockopt(
+                borrowed_fd(fd),
+                level,
+                optname,
+                as_mut_ptr(&mut value).cast(),
+                &mut optlen,
+            ))?;
+            assert_eq!(
+                optlen as usize,
+                size_of::<T>(),
+                "unexpected getsockopt size"
+            );
+            Ok(value.assume_init())
+        }
+    }
+
+    #[inline]
+    fn setsockopt<T>(fd: BorrowedFd<'_>, level: i32, optname: i32, value: T) -> io::Result<()> {
+        use super::*;
+        unsafe {
+            let optlen = std::mem::size_of::<T>().try_into().unwrap();
+            ret(libc::setsockopt(
+                borrowed_fd(fd),
+                level,
+                optname,
+                as_ptr(&value).cast(),
+                optlen,
+            ))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_socket_type(fd: BorrowedFd<'_>) -> io::Result<SocketType> {
+        getsockopt(fd, libc::SOL_SOCKET as _, libc::SO_TYPE)
+    }
+
+    #[inline]
+    pub(crate) fn set_socket_reuseaddr(fd: BorrowedFd<'_>, reuseaddr: bool) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::SOL_SOCKET as _,
+            libc::SO_REUSEADDR,
+            from_bool(reuseaddr),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn set_socket_broadcast(fd: BorrowedFd<'_>, broadcast: bool) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::SOL_SOCKET as _,
+            libc::SO_BROADCAST,
+            from_bool(broadcast),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_socket_broadcast(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::SOL_SOCKET as _, libc::SO_BROADCAST)
+    }
+
+    #[inline]
+    pub(crate) fn set_socket_linger(
+        fd: BorrowedFd<'_>,
+        linger: Option<Duration>,
+    ) -> io::Result<()> {
+        let linger = libc::linger {
+            l_onoff: linger.is_some() as c_int,
+            l_linger: linger.unwrap_or_default().as_secs() as c_int,
+        };
+        setsockopt(fd, libc::SOL_SOCKET as _, libc::SO_LINGER, linger)
+    }
+
+    #[inline]
+    pub(crate) fn get_socket_linger(fd: BorrowedFd<'_>) -> io::Result<Option<Duration>> {
+        let linger: libc::linger = getsockopt(fd, libc::SOL_SOCKET as _, libc::SO_LINGER)?;
+        Ok((linger.l_onoff != 0).then(|| Duration::from_secs(linger.l_linger as u64)))
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[inline]
+    pub(crate) fn set_socket_passcred(fd: BorrowedFd<'_>, passcred: bool) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::SOL_SOCKET as _,
+            libc::SO_PASSCRED,
+            from_bool(passcred),
+        )
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[inline]
+    pub(crate) fn get_socket_passcred(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::SOL_SOCKET as _, libc::SO_PASSCRED)
+    }
+
+    #[inline]
+    pub(crate) fn set_socket_timeout(
+        fd: BorrowedFd<'_>,
+        id: Timeout,
+        timeout: Option<Duration>,
+    ) -> io::Result<()> {
+        let timeout = match timeout {
+            Some(timeout) => {
+                if timeout == Duration::ZERO {
+                    return Err(io::Error::INVAL);
+                }
+
+                let tv_sec = timeout.as_secs().try_into();
+                #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
+                let tv_sec = tv_sec.unwrap_or(std::os::raw::c_long::MAX);
+                #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
+                let tv_sec = tv_sec.unwrap_or(i64::MAX);
+
+                let mut timeout = libc::timeval {
+                    tv_sec,
+                    tv_usec: timeout.subsec_micros() as _,
+                };
+                if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
+                    timeout.tv_usec = 1;
+                }
+                timeout
+            }
+            None => libc::timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            },
+        };
+        let optname = match id {
+            Timeout::Recv => libc::SO_RCVTIMEO,
+            Timeout::Send => libc::SO_SNDTIMEO,
+        };
+        setsockopt(fd, libc::SOL_SOCKET, optname, timeout)
+    }
+
+    #[inline]
+    pub(crate) fn get_socket_timeout(
+        fd: BorrowedFd<'_>,
+        id: Timeout,
+    ) -> io::Result<Option<Duration>> {
+        let optname = match id {
+            Timeout::Recv => libc::SO_RCVTIMEO,
+            Timeout::Send => libc::SO_SNDTIMEO,
+        };
+        let timeout: libc::timeval = getsockopt(fd, libc::SOL_SOCKET, optname)?;
+        if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(
+                Duration::from_secs(timeout.tv_sec as u64)
+                    + Duration::from_micros(timeout.tv_usec as u64),
+            ))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn set_ip_ttl(fd: BorrowedFd<'_>, ttl: u32) -> io::Result<()> {
+        setsockopt(fd, libc::IPPROTO_IP as _, libc::IP_TTL, ttl)
+    }
+
+    #[inline]
+    pub(crate) fn get_ip_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
+        getsockopt(fd, libc::IPPROTO_IP as _, libc::IP_TTL)
+    }
+
+    #[inline]
+    pub(crate) fn set_ipv6_v6only(fd: BorrowedFd<'_>, only_v6: bool) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::IPPROTO_IPV6 as _,
+            libc::IPV6_V6ONLY,
+            from_bool(only_v6),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_ipv6_v6only(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::IPPROTO_IPV6 as _, libc::IPV6_V6ONLY)
+    }
+
+    #[inline]
+    pub(crate) fn set_ip_multicast_loop(
+        fd: BorrowedFd<'_>,
+        multicast_loop: bool,
+    ) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::IPPROTO_IP as _,
+            libc::IP_MULTICAST_LOOP,
+            from_bool(multicast_loop),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_ip_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::IPPROTO_IP as _, libc::IP_MULTICAST_LOOP)
+    }
+
+    #[inline]
+    pub(crate) fn set_ip_multicast_ttl(fd: BorrowedFd<'_>, multicast_ttl: u32) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::IPPROTO_IP as _,
+            libc::IP_MULTICAST_TTL,
+            multicast_ttl,
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_ip_multicast_ttl(fd: BorrowedFd<'_>) -> io::Result<u32> {
+        getsockopt(fd, libc::IPPROTO_IP as _, libc::IP_MULTICAST_TTL)
+    }
+
+    #[inline]
+    pub(crate) fn set_ipv6_multicast_loop(
+        fd: BorrowedFd<'_>,
+        multicast_loop: bool,
+    ) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::IPPROTO_IPV6 as _,
+            libc::IPV6_MULTICAST_LOOP,
+            from_bool(multicast_loop),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_ipv6_multicast_loop(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::IPPROTO_IPV6 as _, libc::IPV6_MULTICAST_LOOP)
+    }
+
+    #[inline]
+    pub(crate) fn set_ip_add_membership(
+        fd: BorrowedFd<'_>,
+        multiaddr: &Ipv4Addr,
+        interface: &Ipv4Addr,
+    ) -> io::Result<()> {
+        let mreq = to_imr(multiaddr, interface);
+        setsockopt(fd, libc::IPPROTO_IP as _, libc::IP_ADD_MEMBERSHIP, mreq)
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    pub(crate) fn set_ipv6_join_group(
+        fd: BorrowedFd<'_>,
+        multiaddr: &Ipv6Addr,
+        interface: u32,
+    ) -> io::Result<()> {
+        let mreq = to_ipv6mr(multiaddr, interface);
+        setsockopt(fd, libc::IPPROTO_IPV6 as _, libc::IPV6_ADD_MEMBERSHIP, mreq)
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    pub(crate) fn set_ip_drop_membership(
+        fd: BorrowedFd<'_>,
+        multiaddr: &Ipv4Addr,
+        interface: &Ipv4Addr,
+    ) -> io::Result<()> {
+        let mreq = to_imr(multiaddr, interface);
+        setsockopt(fd, libc::IPPROTO_IP as _, libc::IP_DROP_MEMBERSHIP, mreq)
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    pub(crate) fn set_ipv6_leave_group(
+        fd: BorrowedFd<'_>,
+        multiaddr: &Ipv6Addr,
+        interface: u32,
+    ) -> io::Result<()> {
+        let mreq = to_ipv6mr(multiaddr, interface);
+        setsockopt(
+            fd,
+            libc::IPPROTO_IPV6 as _,
+            libc::IPV6_DROP_MEMBERSHIP,
+            mreq,
+        )
+    }
+
+    #[inline]
+    pub(crate) fn set_tcp_nodelay(fd: BorrowedFd<'_>, nodelay: bool) -> io::Result<()> {
+        setsockopt(
+            fd,
+            libc::IPPROTO_TCP as _,
+            libc::TCP_NODELAY,
+            from_bool(nodelay),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn get_tcp_nodelay(fd: BorrowedFd<'_>) -> io::Result<bool> {
+        getsockopt(fd, libc::IPPROTO_TCP as _, libc::TCP_NODELAY)
+    }
+
+    #[inline]
+    fn to_imr(multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> libc::ip_mreq {
+        libc::ip_mreq {
+            imr_multiaddr: to_imr_addr(multiaddr),
+            imr_interface: to_imr_addr(interface),
+        }
+    }
+
+    #[inline]
+    fn to_imr_addr(addr: &Ipv4Addr) -> libc::in_addr {
+        libc::in_addr {
+            s_addr: u32::from_ne_bytes(addr.octets()),
+        }
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    fn to_ipv6mr(multiaddr: &Ipv6Addr, interface: u32) -> libc::ipv6_mreq {
+        libc::ipv6_mreq {
+            ipv6mr_multiaddr: to_ipv6mr_multiaddr(multiaddr),
+            ipv6mr_interface: to_ipv6mr_interface(interface),
+        }
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    fn to_ipv6mr_multiaddr(multiaddr: &Ipv6Addr) -> libc::in6_addr {
+        libc::in6_addr {
+            s6_addr: multiaddr.octets(),
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    #[inline]
+    fn to_ipv6mr_interface(interface: u32) -> c_int {
+        interface as c_int
+    }
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd"
+    )))]
+    #[inline]
+    fn to_ipv6mr_interface(interface: u32) -> c_uint {
+        interface as c_uint
+    }
+
+    #[inline]
+    fn from_bool(value: bool) -> c_uint {
+        value as c_uint
     }
 }

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -2495,7 +2495,8 @@ pub(crate) mod sockopt {
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
-        target_os = "netbsd"
+        target_os = "netbsd",
+        target_os = "openbsd"
     )))]
     #[inline]
     pub(crate) fn set_ipv6_join_group(
@@ -2527,7 +2528,8 @@ pub(crate) mod sockopt {
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
-        target_os = "netbsd"
+        target_os = "netbsd",
+        target_os = "openbsd",
     )))]
     #[inline]
     pub(crate) fn set_ipv6_leave_group(

--- a/src/imp/linux_raw/net/mod.rs
+++ b/src/imp/linux_raw/net/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use write_sockaddr::{
 
 pub use addr::{SocketAddr, SocketAddrStorage, SocketAddrUnix};
 pub use send_recv::{RecvFlags, SendFlags};
-pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType};
+pub use types::{AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType, Timeout};
 
 /// Return the offset of the `sun_path` field of `sockaddr_un`.
 #[inline]

--- a/src/imp/linux_raw/net/types.rs
+++ b/src/imp/linux_raw/net/types.rs
@@ -267,3 +267,17 @@ bitflags! {
         const CLOEXEC = linux_raw_sys::general::O_CLOEXEC;
     }
 }
+
+/// Timeout identifier for use with [`set_socket_timeout`] and
+/// [`get_socket_timeout`].
+///
+/// [`set_socket_timeout`]: crate::net::sockopt::set_socket_timeout.
+/// [`get_socket_timeout`]: crate::net::sockopt::get_socket_timeout.
+#[repr(u32)]
+pub enum Timeout {
+    /// `SO_RCVTIMEO`—Timeout for receiving.
+    Recv = linux_raw_sys::general::SO_RCVTIMEO,
+
+    /// `SO_SNDTIMEO`—Timeout for sending.
+    Send = linux_raw_sys::general::SO_SNDTIMEO,
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -7,13 +7,15 @@ mod socket;
 #[cfg(not(target_os = "wasi"))]
 mod socketpair;
 
+pub mod sockopt;
+
 pub use send_recv::{
     recv, recvfrom, send, sendto_unix, sendto_v4, sendto_v6, RecvFlags, SendFlags,
 };
 pub use socket::{
     accept, accept_with, acceptfrom, acceptfrom_with, bind_unix, bind_v4, bind_v6, connect_unix,
-    connect_v4, connect_v6, getpeername, getsockname, getsockopt_socket_type, listen, shutdown,
-    socket, socket_with, AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
+    connect_v4, connect_v6, getpeername, getsockname, listen, shutdown, socket, socket_with,
+    AcceptFlags, AddressFamily, Protocol, Shutdown, SocketFlags, SocketType,
 };
 #[cfg(not(target_os = "wasi"))]
 pub use socketpair::socketpair;

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -265,20 +265,6 @@ pub fn shutdown<Fd: AsFd>(sockfd: &Fd, how: Shutdown) -> io::Result<()> {
     imp::syscalls::shutdown(sockfd, how)
 }
 
-/// `getsockopt(fd, SOL_SOCKET, SO_TYPE)`—Returns the type of a socket.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
-/// [Linux]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
-#[inline]
-pub fn getsockopt_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
-    let fd = fd.as_fd();
-    imp::syscalls::getsockopt_socket_type(fd)
-}
-
 /// `getsockname(fd, addr, len)`—Returns the address a socket is bound to.
 ///
 /// # References

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -433,7 +433,8 @@ pub fn set_ip_add_membership<Fd: AsFd>(
     target_os = "freebsd",
     target_os = "ios",
     target_os = "macos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "openbsd",
 )))]
 #[inline]
 #[doc(alias = "IPV6_JOIN_GROUP")]
@@ -492,7 +493,8 @@ pub fn set_ip_drop_membership<Fd: AsFd>(
     target_os = "freebsd",
     target_os = "ios",
     target_os = "macos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "openbsd",
 )))]
 #[inline]
 #[doc(alias = "IPV6_LEAVE_GROUP")]

--- a/src/net/sockopt.rs
+++ b/src/net/sockopt.rs
@@ -1,0 +1,545 @@
+//! `getsockopt` and `setsockopt` functions.
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "netbsd"
+)))]
+use crate::net::Ipv6Addr;
+use crate::net::{Ipv4Addr, SocketType};
+use crate::{imp, io};
+use io_lifetimes::AsFd;
+use std::time::Duration;
+
+pub use imp::net::Timeout;
+
+/// `getsockopt(fd, SOL_SOCKET, SO_TYPE)`—Returns the type of a socket.
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_TYPE")]
+pub fn get_socket_type<Fd: AsFd>(fd: &Fd) -> io::Result<SocketType> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_socket_type(fd)
+}
+
+/// `setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, value)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_REUSEADDR")]
+pub fn set_socket_reuseaddr<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_socket_reuseaddr(fd, value)
+}
+
+/// `setsockopt(fd, SOL_SOCKET, SO_BROADCAST, broadcast)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_BROADCAST")]
+pub fn set_socket_broadcast<Fd: AsFd>(fd: &Fd, broadcast: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_socket_broadcast(fd, broadcast)
+}
+
+/// `getsockopt(fd, SOL_SOCKET, SO_BROADCAST)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_BROADCAST")]
+pub fn get_socket_broadcast<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_socket_broadcast(fd)
+}
+
+/// `setsockopt(fd, SOL_SOCKET, SO_LINGER, linger)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_LINGER")]
+pub fn set_socket_linger<Fd: AsFd>(fd: &Fd, linger: Option<Duration>) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_socket_linger(fd, linger)
+}
+
+/// `getsockopt(fd, SOL_SOCKET, SO_LINGER)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `getsockopt]
+///  - [Linux `socket`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `getsockopt]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_LINGER")]
+pub fn get_socket_linger<Fd: AsFd>(fd: &Fd) -> io::Result<Option<Duration>> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_socket_linger(fd)
+}
+
+/// `setsockopt(fd, SOL_SOCKET, SO_PASSCRED, passcred)`
+///
+/// # References
+///  - [Linux `setsockopt`]
+///  - [Linux `socket`]
+///
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[cfg(any(target_os = "android", target_os = "linux",))]
+#[inline]
+#[doc(alias = "SO_PASSCRED")]
+pub fn set_socket_passcred<Fd: AsFd>(fd: &Fd, passcred: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_socket_passcred(fd, passcred)
+}
+
+/// `getsockopt(fd, SOL_SOCKET, SO_PASSCRED)`
+///
+/// # References
+///  - [Linux `getsockopt`]
+///  - [Linux `socket`]
+///
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[cfg(any(target_os = "android", target_os = "linux",))]
+#[inline]
+#[doc(alias = "SO_PASSCRED")]
+pub fn get_socket_passcred<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_socket_passcred(fd)
+}
+
+/// `setsockopt(fd, SOL_SOCKET, id, timeout)`—Set the sending
+/// or receiving timeout.
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_RCVTIMEO")]
+#[doc(alias = "SO_SNDTIMEO")]
+pub fn set_socket_timeout<Fd: AsFd>(
+    fd: &Fd,
+    id: Timeout,
+    timeout: Option<Duration>,
+) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_socket_timeout(fd, id, timeout)
+}
+
+/// `getsockopt(fd, SOL_SOCKET, id)`—Get the sending or receiving timeout.
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `sys/socket.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `socket`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `sys/socket.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `socket`]: https://man7.org/linux/man-pages/man7/socket.7.html
+#[inline]
+#[doc(alias = "SO_RCVTIMEO")]
+#[doc(alias = "SO_SNDTIMEO")]
+pub fn get_socket_timeout<Fd: AsFd>(fd: &Fd, id: Timeout) -> io::Result<Option<Duration>> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_socket_timeout(fd, id)
+}
+
+/// `setsockopt(fd, IPPROTO_IP, IP_TTL, ttl)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_TTL")]
+pub fn set_ip_ttl<Fd: AsFd>(fd: &Fd, ttl: u32) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ip_ttl(fd, ttl)
+}
+
+/// `getsockopt(fd, IPPROTO_IP, IP_TTL)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_TTL")]
+pub fn get_ip_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_ip_ttl(fd)
+}
+
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, only_v6)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ipv6`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[inline]
+#[doc(alias = "IPV6_V6ONLY")]
+pub fn set_ipv6_v6only<Fd: AsFd>(fd: &Fd, only_v6: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ipv6_v6only(fd, only_v6)
+}
+
+/// `getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `ipv6`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[inline]
+#[doc(alias = "IPV6_V6ONLY")]
+pub fn get_ipv6_v6only<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_ipv6_v6only(fd)
+}
+
+/// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, multicast_loop)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_MULTICAST_LOOP")]
+pub fn set_ip_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ip_multicast_loop(fd, multicast_loop)
+}
+
+/// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_MULTICAST_LOOP")]
+pub fn get_ip_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_ip_multicast_loop(fd)
+}
+
+/// `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, multicast_ttl)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_MULTICAST_TTL")]
+pub fn set_ip_multicast_ttl<Fd: AsFd>(fd: &Fd, multicast_ttl: u32) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ip_multicast_ttl(fd, multicast_ttl)
+}
+
+/// `getsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_MULTICAST_TTL")]
+pub fn get_ip_multicast_ttl<Fd: AsFd>(fd: &Fd) -> io::Result<u32> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_ip_multicast_ttl(fd)
+}
+
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, multicast_loop)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ipv6`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[inline]
+#[doc(alias = "IPV6_MULTICAST_LOOP")]
+pub fn set_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd, multicast_loop: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ipv6_multicast_loop(fd, multicast_loop)
+}
+
+/// `getsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `ipv6`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[inline]
+#[doc(alias = "IPV6_MULTICAST_LOOP")]
+pub fn get_ipv6_multicast_loop<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_ipv6_multicast_loop(fd)
+}
+
+/// `setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, multiaddr, interface)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[inline]
+#[doc(alias = "IP_ADD_MEMBERSHIP")]
+pub fn set_ip_add_membership<Fd: AsFd>(
+    fd: &Fd,
+    multiaddr: &Ipv4Addr,
+    interface: &Ipv4Addr,
+) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ip_add_membership(fd, multiaddr, interface)
+}
+
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, multiaddr, interface)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt]
+///  - [Linux `ipv6]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "netbsd"
+)))]
+#[inline]
+#[doc(alias = "IPV6_JOIN_GROUP")]
+#[doc(alias = "IPV6_ADD_MEMBERSHIP")]
+pub fn set_ipv6_join_group<Fd: AsFd>(
+    fd: &Fd,
+    multiaddr: &Ipv6Addr,
+    interface: u32,
+) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ipv6_join_group(fd, multiaddr, interface)
+}
+
+/// `setsockopt(fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, multiaddr, interface)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ip`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ip`]: https://man7.org/linux/man-pages/man7/ip.7.html
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "netbsd"
+)))]
+#[inline]
+#[doc(alias = "IP_DROP_MEMBERSHIP")]
+pub fn set_ip_drop_membership<Fd: AsFd>(
+    fd: &Fd,
+    multiaddr: &Ipv4Addr,
+    interface: &Ipv4Addr,
+) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ip_drop_membership(fd, multiaddr, interface)
+}
+
+/// `setsockopt(fd, IPPROTO_IPV6, IPV6_LEAVE_GROUP, multiaddr, interface)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/in.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `ipv6`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/in.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `ipv6`]: https://man7.org/linux/man-pages/man7/ipv6.7.html
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "netbsd"
+)))]
+#[inline]
+#[doc(alias = "IPV6_LEAVE_GROUP")]
+#[doc(alias = "IPV6_DROP_MEMBERSHIP")]
+pub fn set_ipv6_leave_group<Fd: AsFd>(
+    fd: &Fd,
+    multiaddr: &Ipv6Addr,
+    interface: u32,
+) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_ipv6_leave_group(fd, multiaddr, interface)
+}
+
+/// `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, nodelay)`
+///
+/// # References
+///  - [POSIX `setsockopt`]
+///  - [POSIX `netinet/tcp.h`]
+///  - [Linux `setsockopt`]
+///  - [Linux `tcp`]
+///
+/// [POSIX `setsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
+/// [POSIX `netinet/tcp.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_tcp.h.html
+/// [Linux `setsockopt`]: https://man7.org/linux/man-pages/man2/setsockopt.2.html
+/// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
+#[inline]
+#[doc(alias = "TCP_NODELAY")]
+pub fn set_tcp_nodelay<Fd: AsFd>(fd: &Fd, nodelay: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::set_tcp_nodelay(fd, nodelay)
+}
+
+/// `getsockopt(fd, IPPROTO_TCP, TCP_NODELAY)`
+///
+/// # References
+///  - [POSIX `getsockopt`]
+///  - [POSIX `netinet/tcp.h`]
+///  - [Linux `getsockopt`]
+///  - [Linux `tcp`]
+///
+/// [POSIX `getsockopt`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
+/// [POSIX `netinet/tcp.h`]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_tcp.h.html
+/// [Linux `getsockopt`]: https://man7.org/linux/man-pages/man2/getsockopt.2.html
+/// [Linux `tcp`]: https://man7.org/linux/man-pages/man7/tcp.7.html
+#[inline]
+#[doc(alias = "TCP_NODELAY")]
+pub fn get_tcp_nodelay<Fd: AsFd>(fd: &Fd) -> io::Result<bool> {
+    let fd = fd.as_fd();
+    imp::syscalls::sockopt::get_tcp_nodelay(fd)
+}


### PR DESCRIPTION
Add a public `rsix::net::sockopt` module, and put all the `getsockopt`
and `setsockopt` functions in it.