### PR TITLE
Minor code reorganization

### DIFF
--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -1,3 +1,5 @@
+//! The "imp"-lementation module. This selects the backend to use.
+
 #![allow(missing_docs)]
 
 #[cfg(libc)]

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -1,44 +1,11 @@
-//! Functions which operate on file descriptors.
+//! Functions which duplicate file descriptors.
 
 use crate::imp;
 use crate::io::{self, OwnedFd};
 use io_lifetimes::AsFd;
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
-use {io_lifetimes::BorrowedFd, std::ffi::CString};
 
 #[cfg(not(target_os = "wasi"))]
 pub use imp::io::DupFlags;
-
-/// `isatty(fd)`—Tests whether a file descriptor refers to a terminal.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/isatty.html
-/// [Linux]: https://man7.org/linux/man-pages/man3/isatty.3.html
-#[inline]
-pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
-    let fd = fd.as_fd();
-    imp::syscalls::isatty(fd)
-}
-
-/// Returns a pair of booleans indicating whether the file descriptor is
-/// readable and/or writeable, respectively.
-///
-/// Unlike [`is_file_read_write`], this correctly detects whether sockets
-/// have been shutdown, partially or completely.
-///
-/// [`is_file_read_write`]: crate::fs::is_file_read_write
-#[cfg(not(target_os = "redox"))]
-#[inline]
-pub fn is_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
-    let fd = fd.as_fd();
-    imp::syscalls::is_read_write(fd)
-}
 
 /// `dup(fd)`—Creates a new `OwnedFd` instance that shares the same
 /// underlying [file description] as `fd`.
@@ -106,47 +73,4 @@ pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
 pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     let fd = fd.as_fd();
     imp::syscalls::dup2_with(fd, new, flags)
-}
-
-/// `ttyname_r(fd)`
-///
-/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
-///
-/// # References
-///  - [POSIX]
-///  - [Linux]
-///
-/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html
-/// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
-#[inline]
-pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: &Fd, reuse: B) -> io::Result<CString> {
-    let dirfd = dirfd.as_fd();
-    _ttyname(dirfd, reuse.into())
-}
-
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
-))]
-fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
-    // This code would benefit from having a better way to read into
-    // uninitialized memory, but that requires `unsafe`.
-    buffer.clear();
-    buffer.resize(256, 0_u8);
-
-    loop {
-        match imp::syscalls::ttyname(dirfd, &mut buffer) {
-            Err(imp::io::Error::RANGE) => buffer.resize(buffer.len() * 2, 0_u8),
-            Ok(len) => {
-                buffer.resize(len, 0);
-                return Ok(CString::new(buffer).unwrap());
-            }
-            Err(errno) => return Err(errno),
-        }
-    }
 }

--- a/src/io/fd.rs
+++ b/src/io/fd.rs
@@ -12,22 +12,6 @@ use {io_lifetimes::BorrowedFd, std::ffi::CString};
 #[cfg(not(target_os = "wasi"))]
 pub use imp::io::DupFlags;
 
-/// `ioctl(fd, FIONREAD)`—Returns the number of bytes ready to be read.
-///
-/// The result of this function gets silently coerced into a C `int`
-/// by the OS, so it may contain a wrapped value.
-///
-/// # References
-///  - [Linux]
-///
-/// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_tty.2.html
-#[cfg(not(target_os = "redox"))]
-#[inline]
-pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
-    let fd = fd.as_fd();
-    imp::syscalls::ioctl_fionread(fd)
-}
-
 /// `isatty(fd)`—Tests whether a file descriptor refers to a terminal.
 ///
 /// # References

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -84,3 +84,19 @@ pub fn ioctl_tiocnxcl<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
     let fd = fd.as_fd();
     imp::syscalls::ioctl_tiocnxcl(fd)
 }
+
+/// `ioctl(fd, FIONREAD)`—Returns the number of bytes ready to be read.
+///
+/// The result of this function gets silently coerced into a C `int`
+/// by the OS, so it may contain a wrapped value.
+///
+/// # References
+///  - [Linux]
+///
+/// [Linux]: https://man7.org/linux/man-pages/man2/ioctl_tty.2.html
+#[cfg(not(any(windows, target_os = "redox")))]
+#[inline]
+pub fn ioctl_fionread<Fd: AsFd>(fd: &Fd) -> io::Result<u64> {
+    let fd = fd.as_fd();
+    imp::syscalls::ioctl_fionread(fd)
+}

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -1,0 +1,18 @@
+//! Functions which operate on file descriptors.
+
+use crate::imp;
+use crate::io;
+use io_lifetimes::AsFd;
+
+/// Returns a pair of booleans indicating whether the file descriptor is
+/// readable and/or writeable, respectively.
+///
+/// Unlike [`is_file_read_write`], this correctly detects whether sockets
+/// have been shutdown, partially or completely.
+///
+/// [`is_file_read_write`]: crate::fs::is_file_read_write
+#[inline]
+pub fn is_read_write<Fd: AsFd>(fd: &Fd) -> io::Result<(bool, bool)> {
+    let fd = fd.as_fd();
+    imp::syscalls::is_read_write(fd)
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -61,8 +61,6 @@ pub use error::{Error, Result};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use eventfd::{eventfd, EventfdFlags};
 #[cfg(not(any(windows, target_os = "redox")))]
-pub use fd::ioctl_fionread;
-#[cfg(not(any(windows, target_os = "redox")))]
 pub use fd::is_read_write;
 #[cfg(not(windows))]
 pub use fd::isatty;
@@ -78,6 +76,8 @@ pub use imp::io::epoll;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use ioctl::ioctl_fioclex;
 pub use ioctl::ioctl_fionbio;
+#[cfg(not(any(windows, target_os = "redox")))]
+pub use ioctl::ioctl_fionread;
 #[cfg(not(any(windows, target_os = "wasi")))]
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
 #[cfg(any(

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -30,12 +30,14 @@ pub(crate) use {
 
 #[cfg(not(windows))]
 mod close;
+#[cfg(not(windows))]
+mod dup;
 mod error;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 mod eventfd;
-#[cfg(not(windows))]
-mod fd;
 mod ioctl;
+#[cfg(not(any(windows, target_os = "redox")))]
+mod is_read_write;
 #[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
 mod madvise;
 #[cfg(not(any(windows, target_os = "wasi")))]
@@ -52,25 +54,18 @@ mod procfs;
 mod read_write;
 #[cfg(not(windows))]
 mod stdio;
+#[cfg(not(windows))]
+mod tty;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 mod userfaultfd;
 
 #[cfg(not(windows))]
 pub use close::close;
+#[cfg(not(any(windows, target_os = "wasi")))]
+pub use dup::{dup, dup2, dup2_with, DupFlags};
 pub use error::{Error, Result};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use eventfd::{eventfd, EventfdFlags};
-#[cfg(not(any(windows, target_os = "redox")))]
-pub use fd::is_read_write;
-#[cfg(not(windows))]
-pub use fd::isatty;
-#[cfg(any(
-    all(linux_raw, feature = "procfs"),
-    all(libc, not(any(windows, target_os = "fuchsia", target_os = "wasi")))
-))]
-pub use fd::ttyname;
-#[cfg(not(any(windows, target_os = "wasi")))]
-pub use fd::{dup, dup2, dup2_with, DupFlags};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use imp::io::epoll;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -85,6 +80,8 @@ pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
     all(libc, not(any(windows, target_os = "redox", target_os = "wasi")))
 ))]
 pub use ioctl::{ioctl_tiocexcl, ioctl_tiocnxcl};
+#[cfg(not(any(windows, target_os = "redox")))]
+pub use is_read_write::is_read_write;
 #[cfg(not(any(windows, target_os = "redox", target_os = "wasi")))]
 pub use madvise::{madvise, Advice};
 #[cfg(not(any(windows, target_os = "wasi")))]
@@ -113,6 +110,13 @@ pub use read_write::{preadv, pwritev};
 pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
 #[cfg(not(windows))]
 pub use stdio::{stderr, stdin, stdout, take_stderr, take_stdin, take_stdout};
+#[cfg(not(windows))]
+pub use tty::isatty;
+#[cfg(any(
+    all(linux_raw, feature = "procfs"),
+    all(libc, not(any(windows, target_os = "fuchsia", target_os = "wasi")))
+))]
+pub use tty::ttyname;
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use userfaultfd::{userfaultfd, UserfaultfdFlags};
 

--- a/src/io/tty.rs
+++ b/src/io/tty.rs
@@ -1,0 +1,72 @@
+//! Functions which operate on file descriptors.
+
+use crate::imp;
+#[cfg(any(
+    all(linux_raw, feature = "procfs"),
+    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
+))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+use crate::io;
+use io_lifetimes::AsFd;
+#[cfg(any(
+    all(linux_raw, feature = "procfs"),
+    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
+))]
+use {io_lifetimes::BorrowedFd, std::ffi::CString};
+
+/// `isatty(fd)`—Tests whether a file descriptor refers to a terminal.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/isatty.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/isatty.3.html
+#[inline]
+pub fn isatty<Fd: AsFd>(fd: &Fd) -> bool {
+    let fd = fd.as_fd();
+    imp::syscalls::isatty(fd)
+}
+
+/// `ttyname_r(fd)`
+///
+/// If `reuse` is non-empty, reuse its buffer to store the result if possible.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/ttyname.3.html
+#[cfg(any(
+    all(linux_raw, feature = "procfs"),
+    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
+))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "procfs")))]
+#[inline]
+pub fn ttyname<Fd: AsFd, B: Into<Vec<u8>>>(dirfd: &Fd, reuse: B) -> io::Result<CString> {
+    let dirfd = dirfd.as_fd();
+    _ttyname(dirfd, reuse.into())
+}
+
+#[cfg(any(
+    all(linux_raw, feature = "procfs"),
+    all(libc, not(any(target_os = "fuchsia", target_os = "wasi")))
+))]
+fn _ttyname(dirfd: BorrowedFd<'_>, mut buffer: Vec<u8>) -> io::Result<CString> {
+    // This code would benefit from having a better way to read into
+    // uninitialized memory, but that requires `unsafe`.
+    buffer.clear();
+    buffer.resize(256, 0_u8);
+
+    loop {
+        match imp::syscalls::ttyname(dirfd, &mut buffer) {
+            Err(imp::io::Error::RANGE) => buffer.resize(buffer.len() * 2, 0_u8),
+            Ok(len) => {
+                buffer.resize(len, 0);
+                return Ok(CString::new(buffer).unwrap());
+            }
+            Err(errno) => return Err(errno),
+        }
+    }
+}


### PR DESCRIPTION
Add comments, move an `ioctl` function into ioctl.rs, and split `fd.rs` into separate files.