### PR TITLE
allocate for execve outside of `imp::syscalls`

### DIFF
--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -1567,15 +1567,17 @@ pub(crate) unsafe fn fork() -> io::Result<Pid> {
     Ok(Pid::from_raw(pid))
 }
 
-pub(crate) fn execve(path: &ZStr, args: &[*const u8], env_vars: &[*const u8]) -> io::Result<()> {
-    unsafe {
-        ret(syscall3_readonly(
-            nr(__NR_execve),
-            c_str(path),
-            slice_just_addr(&args),
-            slice_just_addr(&env_vars),
-        ))
-    }
+pub(crate) unsafe fn execve(
+    path: &ZStr,
+    args: &[*const u8],
+    env_vars: &[*const u8],
+) -> io::Result<()> {
+    ret(syscall3_readonly(
+        nr(__NR_execve),
+        c_str(path),
+        slice_just_addr(&args),
+        slice_just_addr(&env_vars),
+    ))
 }
 
 #[inline]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -148,5 +148,7 @@ pub fn execve<P: Arg, A: Arg, E: Arg>(path: P, args: &[A], env_vars: &[E]) -> io
         .map(|zstr| ZStr::as_ptr(zstr).cast::<_>())
         .chain(core::iter::once(core::ptr::null()))
         .collect();
-    path.into_with_z_str(|path_cstr| imp::syscalls::execve(path_cstr, &arg_ptrs, &env_ptrs))
+    path.into_with_z_str(|path_cstr| unsafe {
+        imp::syscalls::execve(path_cstr, &arg_ptrs, &env_ptrs)
+    })
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -124,6 +124,20 @@ pub unsafe fn fork() -> io::Result<Pid> {
     imp::syscalls::fork()
 }
 
+fn _execve(path: &ZStr, arg_zstr: &[Cow<'_, ZStr>], env_zstr: &[Cow<'_, ZStr>]) -> io::Result<()> {
+    let arg_ptrs: Vec<_> = arg_zstr
+        .iter()
+        .map(|zstr| ZStr::as_ptr(zstr).cast::<_>())
+        .chain(core::iter::once(core::ptr::null()))
+        .collect();
+    let env_ptrs: Vec<_> = env_zstr
+        .iter()
+        .map(|zstr| ZStr::as_ptr(zstr).cast::<_>())
+        .chain(core::iter::once(core::ptr::null()))
+        .collect();
+    unsafe { imp::syscalls::execve(path, &arg_ptrs, &env_ptrs) }
+}
+
 /// Executes the program pointed to by `path`, with the arguments `args`,
 /// and the environment variables `env_vars`.
 ///
@@ -134,21 +148,9 @@ pub fn execve<P: Arg, A: Arg, E: Arg>(path: P, args: &[A], env_vars: &[E]) -> io
         .iter()
         .map(Arg::as_cow_z_str)
         .collect::<io::Result<_>>()?;
-    let arg_ptrs: Vec<_> = arg_zstr
-        .iter()
-        .map(|zstr| ZStr::as_ptr(zstr).cast::<_>())
-        .chain(core::iter::once(core::ptr::null()))
-        .collect();
     let env_zstr: Vec<Cow<'_, ZStr>> = env_vars
         .iter()
         .map(Arg::as_cow_z_str)
         .collect::<io::Result<_>>()?;
-    let env_ptrs: Vec<_> = env_zstr
-        .iter()
-        .map(|zstr| ZStr::as_ptr(zstr).cast::<_>())
-        .chain(core::iter::once(core::ptr::null()))
-        .collect();
-    path.into_with_z_str(|path_cstr| unsafe {
-        imp::syscalls::execve(path_cstr, &arg_ptrs, &env_ptrs)
-    })
+    path.into_with_z_str(|path_zstr| _execve(path_zstr, &arg_zstr, &env_zstr))
 }


### PR DESCRIPTION
this moves all allocations outside the call to `imp::syscalls::execve`,
this would allow a future implementation of `posix_spawn` to use `execve` in the child process without worrying about the allocator lock causing deadlock.

essentially the idea is that functions that would be used inside `posix_spawn` would be `imp::syscalls` functions, which are safe to call inside `fork`/`vfork`, without constraining the public API to be `async-signal-safe`.